### PR TITLE
Refactor and split Reach into 4 checks. Fix some HitboxEntity falses.

### DIFF
--- a/src/main/java/ac/grim/grimac/checks/impl/combat/HitboxBlock.java
+++ b/src/main/java/ac/grim/grimac/checks/impl/combat/HitboxBlock.java
@@ -1,9 +1,11 @@
 package ac.grim.grimac.checks.impl.combat;
 
 import ac.grim.grimac.checks.Check;
+import ac.grim.grimac.checks.CheckData;
 import ac.grim.grimac.checks.type.PacketCheck;
 import ac.grim.grimac.player.GrimPlayer;
 
+@CheckData(name = "HitboxBlock", configName = "HitboxBlock", setback = 20)
 public class HitboxBlock extends Check implements PacketCheck {
     public HitboxBlock(GrimPlayer player) {
         super(player);

--- a/src/main/java/ac/grim/grimac/checks/impl/combat/HitboxBlock.java
+++ b/src/main/java/ac/grim/grimac/checks/impl/combat/HitboxBlock.java
@@ -1,0 +1,11 @@
+package ac.grim.grimac.checks.impl.combat;
+
+import ac.grim.grimac.checks.Check;
+import ac.grim.grimac.checks.type.PacketCheck;
+import ac.grim.grimac.player.GrimPlayer;
+
+public class HitboxBlock extends Check implements PacketCheck {
+    public HitboxBlock(GrimPlayer player) {
+        super(player);
+    }
+}

--- a/src/main/java/ac/grim/grimac/checks/impl/combat/HitboxEntity.java
+++ b/src/main/java/ac/grim/grimac/checks/impl/combat/HitboxEntity.java
@@ -1,9 +1,11 @@
 package ac.grim.grimac.checks.impl.combat;
 
 import ac.grim.grimac.checks.Check;
+import ac.grim.grimac.checks.CheckData;
 import ac.grim.grimac.checks.type.PacketCheck;
 import ac.grim.grimac.player.GrimPlayer;
 
+@CheckData(name = "HitboxEntity", configName = "HitboxEntity", setback = 30)
 public class HitboxEntity extends Check implements PacketCheck {
     public HitboxEntity(GrimPlayer player) {
         super(player);

--- a/src/main/java/ac/grim/grimac/checks/impl/combat/HitboxEntity.java
+++ b/src/main/java/ac/grim/grimac/checks/impl/combat/HitboxEntity.java
@@ -1,0 +1,11 @@
+package ac.grim.grimac.checks.impl.combat;
+
+import ac.grim.grimac.checks.Check;
+import ac.grim.grimac.checks.type.PacketCheck;
+import ac.grim.grimac.player.GrimPlayer;
+
+public class HitboxEntity extends Check implements PacketCheck {
+    public HitboxEntity(GrimPlayer player) {
+        super(player);
+    }
+}

--- a/src/main/java/ac/grim/grimac/checks/impl/combat/HitboxMiss.java
+++ b/src/main/java/ac/grim/grimac/checks/impl/combat/HitboxMiss.java
@@ -1,0 +1,11 @@
+package ac.grim.grimac.checks.impl.combat;
+
+import ac.grim.grimac.checks.Check;
+import ac.grim.grimac.checks.type.PacketCheck;
+import ac.grim.grimac.player.GrimPlayer;
+
+public class HitboxMiss extends Check implements PacketCheck {
+    public HitboxMiss(GrimPlayer player) {
+        super(player);
+    }
+}

--- a/src/main/java/ac/grim/grimac/checks/impl/combat/HitboxMiss.java
+++ b/src/main/java/ac/grim/grimac/checks/impl/combat/HitboxMiss.java
@@ -1,9 +1,11 @@
 package ac.grim.grimac.checks.impl.combat;
 
 import ac.grim.grimac.checks.Check;
+import ac.grim.grimac.checks.CheckData;
 import ac.grim.grimac.checks.type.PacketCheck;
 import ac.grim.grimac.player.GrimPlayer;
 
+@CheckData(name = "HitboxMiss", configName = "HitboxMiss", setback = 10)
 public class HitboxMiss extends Check implements PacketCheck {
     public HitboxMiss(GrimPlayer player) {
         super(player);

--- a/src/main/java/ac/grim/grimac/checks/impl/combat/Reach.java
+++ b/src/main/java/ac/grim/grimac/checks/impl/combat/Reach.java
@@ -235,8 +235,8 @@ public class Reach extends Check implements PacketCheck {
         // +3 would be 3 + 3 = 6, which is the pre-1.20.5 behaviour, preventing "Missed Hitbox"
         final double distance = player.compensatedEntities.getSelf().getAttributeValue(Attributes.ENTITY_INTERACTION_RANGE) + 3;
         double[] possibleEyeHeights = player.getPossibleEyeHeights();
-        possibleEyeHeights = new double[]{possibleEyeHeights[0]};
-        double realMinDistance = 0;
+//        possibleEyeHeights = new double[]{possibleEyeHeights[0]};
+//        double realMinDistance = 0;
         for (Vector lookVec : possibleLookDirs) {
             for (double eye : possibleEyeHeights) {
                 Vector eyePos = new Vector(from.getX(), from.getY() + eye, from.getZ());
@@ -251,9 +251,9 @@ public class Reach extends Check implements PacketCheck {
 
                 if (intercept != null) {
                     minDistance = Math.min(eyePos.distance(intercept), minDistance);
-                    if (eye == possibleEyeHeights[0]) {
-                        realMinDistance = minDistance;
-                    }
+//                    if (eye == possibleEyeHeights[0]) {
+//                        realMinDistance = minDistance;
+//                    }
                 }
             }
         }
@@ -289,7 +289,7 @@ public class Reach extends Check implements PacketCheck {
             } else if (minDistance == Double.MAX_VALUE) {
                 cancelBuffer = 1;
                 return new Pair<>(HitboxMiss.class, "");
-            } else if (realMinDistance > player.compensatedEntities.getSelf().getAttributeValue(Attributes.ENTITY_INTERACTION_RANGE)) {
+            } else if (minDistance > player.compensatedEntities.getSelf().getAttributeValue(Attributes.ENTITY_INTERACTION_RANGE)) {
                 cancelBuffer = 1;
                 return new Pair<>(Reach.class, String.format("%.5f", minDistance) + " blocks");
             } else {

--- a/src/main/java/ac/grim/grimac/checks/impl/combat/Reach.java
+++ b/src/main/java/ac/grim/grimac/checks/impl/combat/Reach.java
@@ -340,6 +340,10 @@ public class Reach extends Check implements PacketCheck {
                         bestBlockingEntityHit = hitResult;
                     }
                 } else if (hitResult instanceof BlockHitData) {
+                    // don't false on recently rapidly changed blocks
+                    if (distanceSquared < (minDistance * minDistance) && blocksChangedThisTick.contains(((BlockHitData) hitResult).getPosition())) {
+                        return null;
+                    }
                     // Check if block is closer than any blocking entity found
                     if (bestBlockingEntityHit == null && distanceSquared < bestDistanceSq) {
                         bestDistanceSq = distanceSquared;

--- a/src/main/java/ac/grim/grimac/events/packets/PacketEntityReplication.java
+++ b/src/main/java/ac/grim/grimac/events/packets/PacketEntityReplication.java
@@ -441,10 +441,12 @@ public class PacketEntityReplication extends Check implements PacketCheck {
                     return;
                 }
 
+                player.compensatedEntities.entityMap.updateEntityPosition(player.compensatedEntities.entityMap.get(entityId), new Vector3d(data.getX() + deltaX, data.getY() + deltaY, data.getZ() + deltaZ));
                 data.setX(data.getX() + deltaX);
                 data.setY(data.getY() + deltaY);
                 data.setZ(data.getZ() + deltaZ);
             } else {
+                player.compensatedEntities.entityMap.updateEntityPosition(player.compensatedEntities.entityMap.get(entityId), new Vector3d(deltaX, deltaY, deltaZ));
                 data.setX(deltaX);
                 data.setY(deltaY);
                 data.setZ(deltaZ);

--- a/src/main/java/ac/grim/grimac/events/packets/PacketPlayerJoinQuit.java
+++ b/src/main/java/ac/grim/grimac/events/packets/PacketPlayerJoinQuit.java
@@ -36,9 +36,6 @@ public class PacketPlayerJoinQuit extends PacketListenerAbstract {
         }
         if (player.hasPermission("grim.alerts") && player.hasPermission("grim.alerts.enable-on-join")) {
             GrimAPI.INSTANCE.getAlertManager().toggleAlerts(player);
-            if (player.hasPermission("grim.verbose") && player.hasPermission("grim.verbose.enable-on-join")) {
-                GrimAPI.INSTANCE.getAlertManager().toggleVerbose(player);
-            }
         }
         if (player.hasPermission("grim.spectate") && GrimAPI.INSTANCE.getConfigManager().getConfig().getBooleanElse("spectators.hide-regardless", false)) {
             GrimAPI.INSTANCE.getSpectateManager().onLogin(player);

--- a/src/main/java/ac/grim/grimac/manager/CheckManager.java
+++ b/src/main/java/ac/grim/grimac/manager/CheckManager.java
@@ -5,9 +5,7 @@ import ac.grim.grimac.checks.impl.aim.AimDuplicateLook;
 import ac.grim.grimac.checks.impl.aim.AimModulo360;
 import ac.grim.grimac.checks.impl.aim.processor.AimProcessor;
 import ac.grim.grimac.checks.impl.badpackets.*;
-import ac.grim.grimac.checks.impl.combat.MultiInteractA;
-import ac.grim.grimac.checks.impl.combat.MultiInteractB;
-import ac.grim.grimac.checks.impl.combat.Reach;
+import ac.grim.grimac.checks.impl.combat.*;
 import ac.grim.grimac.checks.impl.crash.*;
 import ac.grim.grimac.checks.impl.exploit.ExploitA;
 import ac.grim.grimac.checks.impl.exploit.ExploitB;
@@ -72,6 +70,9 @@ public class CheckManager {
         packetChecks = new ImmutableClassToInstanceMap.Builder<PacketCheck>()
                 .put(PacketOrderProcessor.class, player.packetOrderProcessor)
                 .put(Reach.class, new Reach(player))
+                .put(HitboxMiss.class, new HitboxMiss(player))
+                .put(HitboxBlock.class, new HitboxBlock(player))
+                .put(HitboxEntity.class, new HitboxEntity(player))
                 .put(PacketEntityReplication.class, new PacketEntityReplication(player))
                 .put(PacketChangeGameState.class, new PacketChangeGameState(player))
                 .put(CompensatedInventory.class, new CompensatedInventory(player))

--- a/src/main/java/ac/grim/grimac/utils/collisions/HitboxData.java
+++ b/src/main/java/ac/grim/grimac/utils/collisions/HitboxData.java
@@ -577,7 +577,7 @@ public enum HitboxData {
             int flowerAmount = data.getFlowerAmount();
             int horizontalIndex = getHorizontalID(data.getFacing());
 
-            CollisionBox result = NoCollisionBox.INSTANCE;
+            CollisionBox result = flowerAmount < 2 ? NoCollisionBox.INSTANCE : new ComplexCollisionBox(flowerAmount);
 
             // Pre-defined collision boxes for each quadrant
             HexCollisionBox[] boxes = new HexCollisionBox[] {

--- a/src/main/java/ac/grim/grimac/utils/data/packetentity/dragon/PacketEntityEnderDragon.java
+++ b/src/main/java/ac/grim/grimac/utils/data/packetentity/dragon/PacketEntityEnderDragon.java
@@ -2,8 +2,8 @@ package ac.grim.grimac.utils.data.packetentity.dragon;
 
 import ac.grim.grimac.player.GrimPlayer;
 import ac.grim.grimac.utils.data.packetentity.PacketEntity;
+import ac.grim.grimac.utils.latency.SectionedEntityMap;
 import com.github.retrooper.packetevents.protocol.entity.type.EntityTypes;
-import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -15,7 +15,7 @@ public final class PacketEntityEnderDragon extends PacketEntity {
 
     public PacketEntityEnderDragon(GrimPlayer player, UUID uuid, int entityID, double x, double y, double z) {
         super(player, uuid, EntityTypes.ENDER_DRAGON, x, y, z);
-        final Int2ObjectOpenHashMap<PacketEntity> entityMap = player.compensatedEntities.entityMap;
+        final SectionedEntityMap entityMap = player.compensatedEntities.entityMap;
         parts.add(new PacketEntityEnderDragonPart(player, DragonPart.HEAD, x, y, z, 1.0F, 1.0F));
         parts.add(new PacketEntityEnderDragonPart(player, DragonPart.NECK, x, y, z, 3.0F, 3.0F));
         parts.add(new PacketEntityEnderDragonPart(player, DragonPart.BODY, x, y, z, 5.0F, 3.0F));

--- a/src/main/java/ac/grim/grimac/utils/latency/CompensatedEntities.java
+++ b/src/main/java/ac/grim/grimac/utils/latency/CompensatedEntities.java
@@ -34,8 +34,9 @@ public class CompensatedEntities {
     public static final UUID SPRINTING_MODIFIER_UUID = UUID.fromString("662A6B8D-DA3E-4C1C-8813-96EA6097278D");
     public static final UUID SNOW_MODIFIER_UUID = UUID.fromString("1eaf83ff-7207-4596-b37a-d7a07b3ec4ce");
 
-    public final Int2ObjectOpenHashMap<PacketEntity> entityMap = new Int2ObjectOpenHashMap<>(40, 0.7f);
-    public final Int2ObjectOpenHashMap<TrackerData> serverPositionsMap = new Int2ObjectOpenHashMap<>(40, 0.7f);
+    public final SectionedEntityMap entityMap = new SectionedEntityMap();
+//    public final Int2ObjectLinkedOpenHashMap<PacketEntity> entityMap = new Int2ObjectLinkedOpenHashMap<>(40, 0.7f); // needs to be linked to replicate vanilla iteration order!
+    public final Int2ObjectOpenHashMap<TrackerData> serverPositionsMap = new Int2ObjectOpenHashMap<>(40, 0.7f); // never iterate over, so iteration order does not matter
     public final Object2ObjectOpenHashMap<UUID, UserProfile> profiles = new Object2ObjectOpenHashMap<>();
     public Integer serverPlayerVehicle = null;
     public boolean hasSprintingAttributeEnabled = false;
@@ -70,13 +71,15 @@ public class CompensatedEntities {
     }
 
     public void removeEntity(int entityID) {
-        PacketEntity entity = entityMap.remove(entityID);
+        PacketEntity entity = entityMap.get(entityID);
         if (entity == null) return;
+
+        entityMap.removeEntity(entityID);
 
         if (entity instanceof PacketEntityEnderDragon) {
             PacketEntityEnderDragon dragon = (PacketEntityEnderDragon) entity;
             for (int i = 1; i < dragon.getParts().size() + 1; i++) {
-                entityMap.remove(entityID + i);
+                entityMap.removeEntity(entityID + i);
             }
         }
 

--- a/src/main/java/ac/grim/grimac/utils/latency/SectionedEntityMap.java
+++ b/src/main/java/ac/grim/grimac/utils/latency/SectionedEntityMap.java
@@ -1,0 +1,107 @@
+package ac.grim.grimac.utils.latency;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Consumer;
+
+import ac.grim.grimac.utils.collisions.datatypes.SimpleCollisionBox;
+import ac.grim.grimac.utils.data.packetentity.PacketEntity;
+import ac.grim.grimac.utils.math.GrimMath;
+import com.github.retrooper.packetevents.util.Vector3d;
+import it.unimi.dsi.fastutil.longs.Long2ObjectOpenHashMap;
+import it.unimi.dsi.fastutil.longs.LongAVLTreeSet;
+import it.unimi.dsi.fastutil.longs.LongSortedSet;
+
+public class SectionedEntityMap {
+
+    private final Long2ObjectOpenHashMap<EntitySection> sections = new Long2ObjectOpenHashMap<>();
+    private final LongSortedSet trackedSections = new LongAVLTreeSet();
+
+    public void addEntity(PacketEntity entity) {
+        Vector3d entityLocation = entity.trackedServerPosition.getPos();
+        long sectionPos = GrimMath.asLong(
+                GrimMath.getSectionCoord(entityLocation.getX()),
+                GrimMath.getSectionCoord(entityLocation.getY()),
+                GrimMath.getSectionCoord(entityLocation.getZ())
+        );
+
+        EntitySection section = sections.computeIfAbsent(sectionPos, this::createSection);
+        section.addEntity(entity);
+        trackedSections.add(sectionPos);
+    }
+
+    public void removeEntity(PacketEntity entity) {
+        Vector3d entityLocation = entity.trackedServerPosition.getPos();
+        long sectionPos = GrimMath.asLong(
+                GrimMath.getSectionCoord(entityLocation.getX()),
+                GrimMath.getSectionCoord(entityLocation.getY()),
+                GrimMath.getSectionCoord(entityLocation.getZ())
+        );
+
+        EntitySection section = sections.get(sectionPos);
+        if (section != null) {
+            section.removeEntity(entity);
+            if (section.isEmpty()) {
+                sections.remove(sectionPos);
+                trackedSections.remove(sectionPos);
+            }
+        }
+    }
+
+    public void forEachInBox(SimpleCollisionBox box, Consumer<PacketEntity> action) {
+        int minX = GrimMath.getSectionCoord(box.minX - 2.0);
+        int minY = GrimMath.getSectionCoord(box.minY - 4.0);
+        int minZ = GrimMath.getSectionCoord(box.minZ - 2.0);
+        int maxX = GrimMath.getSectionCoord(box.maxX + 2.0);
+        int maxY = GrimMath.getSectionCoord(box.maxY);
+        int maxZ = GrimMath.getSectionCoord(box.maxZ + 2.0);
+
+        for (int x = minX; x <= maxX; x++) {
+            long minPacked = GrimMath.asLong(x, 0, 0);
+            long maxPacked = GrimMath.asLong(x, -1, -1);
+            LongSortedSet relevantSections = trackedSections.subSet(minPacked, maxPacked + 1);
+
+            for (long sectionPos : relevantSections) {
+                int y = GrimMath.unpackY(sectionPos);
+                int z = GrimMath.unpackZ(sectionPos);
+
+                if (y >= minY && y <= maxY && z >= minZ && z <= maxZ) {
+                    EntitySection section = sections.get(sectionPos);
+                    if (section != null) {
+                        section.forEachEntity(action);
+                    }
+                }
+            }
+        }
+    }
+
+    private EntitySection createSection(long pos) {
+        return new EntitySection();
+    }
+
+    private static class EntitySection {
+        private final List<PacketEntity> entities = new ArrayList<>();
+
+        public void addEntity(PacketEntity entity) {
+            entities.add(entity);
+        }
+
+        public void removeEntity(PacketEntity entity) {
+            entities.remove(entity);
+        }
+
+        public boolean isEmpty() {
+            return entities.isEmpty();
+        }
+
+        public void forEachEntity(Consumer<PacketEntity> action) {
+            for (PacketEntity entity : entities) { // Iterate in insertion order (oldest first)
+                action.accept(entity);
+            }
+        }
+
+        public List<PacketEntity> getEntities() {
+            return entities;
+        }
+    }
+}

--- a/src/main/java/ac/grim/grimac/utils/latency/SectionedEntityMap.java
+++ b/src/main/java/ac/grim/grimac/utils/latency/SectionedEntityMap.java
@@ -1,23 +1,33 @@
 package ac.grim.grimac.utils.latency;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.util.*;
 import java.util.function.Consumer;
 
 import ac.grim.grimac.utils.collisions.datatypes.SimpleCollisionBox;
 import ac.grim.grimac.utils.data.packetentity.PacketEntity;
 import ac.grim.grimac.utils.math.GrimMath;
 import com.github.retrooper.packetevents.util.Vector3d;
+import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
 import it.unimi.dsi.fastutil.longs.Long2ObjectOpenHashMap;
 import it.unimi.dsi.fastutil.longs.LongAVLTreeSet;
 import it.unimi.dsi.fastutil.longs.LongSortedSet;
 
 public class SectionedEntityMap {
 
+    // exists to make porting over the legacy entity handling easier, will remove later
+    private final Int2ObjectOpenHashMap<PacketEntity> idToEntity = new Int2ObjectOpenHashMap<>();
+
     private final Long2ObjectOpenHashMap<EntitySection> sections = new Long2ObjectOpenHashMap<>();
     private final LongSortedSet trackedSections = new LongAVLTreeSet();
 
-    public void addEntity(PacketEntity entity) {
+    private final EntityCollection entityCollection = new EntityCollection();
+
+    public PacketEntity get(int entityId) {
+        return idToEntity.get(entityId);
+    }
+
+    public void addEntity(int entityID, PacketEntity entity) {
+        idToEntity.put(entityID, entity);
         Vector3d entityLocation = entity.trackedServerPosition.getPos();
         long sectionPos = GrimMath.asLong(
                 GrimMath.getSectionCoord(entityLocation.getX()),
@@ -28,6 +38,13 @@ public class SectionedEntityMap {
         EntitySection section = sections.computeIfAbsent(sectionPos, this::createSection);
         section.addEntity(entity);
         trackedSections.add(sectionPos);
+    }
+
+    public void removeEntity(int entityId) {
+        PacketEntity entity = idToEntity.remove(entityId);
+        if (entity != null) {
+            removeEntity(entity);
+        }
     }
 
     public void removeEntity(PacketEntity entity) {
@@ -44,6 +61,26 @@ public class SectionedEntityMap {
             if (section.isEmpty()) {
                 sections.remove(sectionPos);
                 trackedSections.remove(sectionPos);
+            }
+        }
+    }
+
+    public Collection<PacketEntity> values() {
+        return entityCollection;
+    }
+
+    public boolean containsKey(int entityId) {
+        return idToEntity.containsKey(entityId);
+    }
+
+    public void forEachEntity(Consumer<PacketEntity> action) {
+        long minPacked = Long.MIN_VALUE;
+        long maxPacked = Long.MAX_VALUE;
+
+        for (long sectionPos : trackedSections.subSet(minPacked, maxPacked)) {
+            EntitySection section = sections.get(sectionPos);
+            if (section != null) {
+                section.forEachEntity(action);
             }
         }
     }
@@ -75,8 +112,61 @@ public class SectionedEntityMap {
         }
     }
 
+    public void updateEntityPosition(PacketEntity entity, Vector3d newPosition) {
+        if (entity == null) return; // is null on startup at first
+        // Get old and new section positions
+        Vector3d oldPosition = entity.trackedServerPosition.getPos();
+        long oldSectionPos = GrimMath.asLong(
+                GrimMath.getSectionCoord(oldPosition.getX()),
+                GrimMath.getSectionCoord(oldPosition.getY()),
+                GrimMath.getSectionCoord(oldPosition.getZ())
+        );
+
+        long newSectionPos = GrimMath.asLong(
+                GrimMath.getSectionCoord(newPosition.getX()),
+                GrimMath.getSectionCoord(newPosition.getY()),
+                GrimMath.getSectionCoord(newPosition.getZ())
+        );
+
+        // If section changed
+        if (oldSectionPos != newSectionPos) {
+            // Remove from old section
+            EntitySection oldSection = sections.get(oldSectionPos);
+            if (oldSection != null) {
+                oldSection.removeEntity(entity);
+                if (oldSection.isEmpty()) {
+                    sections.remove(oldSectionPos);
+                    trackedSections.remove(oldSectionPos);
+                }
+            }
+
+            // Add to new section
+            EntitySection newSection = sections.computeIfAbsent(newSectionPos, this::createSection);
+            newSection.addEntity(entity);
+            trackedSections.add(newSectionPos);
+        }
+    }
+
     private EntitySection createSection(long pos) {
         return new EntitySection();
+    }
+
+    public Iterable<? extends Map.Entry<Integer, PacketEntity>> int2ObjectEntrySet() {
+        return idToEntity.entrySet();
+    }
+
+    public void put(int entityID, PacketEntity packetEntity) {
+        addEntity(entityID, packetEntity);
+    }
+
+    public boolean containsValue(PacketEntity entity) {
+        return idToEntity.containsValue(entity);
+    }
+
+    public void clear() {
+        idToEntity.clear();
+        sections.clear();
+        trackedSections.clear();
     }
 
     private static class EntitySection {
@@ -102,6 +192,48 @@ public class SectionedEntityMap {
 
         public List<PacketEntity> getEntities() {
             return entities;
+        }
+    }
+
+    private class EntityCollection extends AbstractCollection<PacketEntity> {
+        @Override
+        public Iterator<PacketEntity> iterator() {
+            return new EntityIterator();
+        }
+
+        @Override
+        public int size() {
+            return idToEntity.size();
+        }
+
+        @Override
+        public boolean contains(Object o) {
+            return o instanceof PacketEntity && containsValue((PacketEntity) o);
+        }
+    }
+
+    private class EntityIterator implements Iterator<PacketEntity> {
+        private final Iterator<Long> sectionIterator = trackedSections.iterator();
+        private Iterator<PacketEntity> currentSectionIterator = Collections.emptyIterator();
+
+        @Override
+        public boolean hasNext() {
+            while (!currentSectionIterator.hasNext() && sectionIterator.hasNext()) {
+                long sectionPos = sectionIterator.next();
+                EntitySection section = sections.get(sectionPos);
+                if (section != null) {
+                    currentSectionIterator = section.getEntities().iterator();
+                }
+            }
+            return currentSectionIterator.hasNext();
+        }
+
+        @Override
+        public PacketEntity next() {
+            if (!hasNext()) {
+                throw new NoSuchElementException();
+            }
+            return currentSectionIterator.next();
         }
     }
 }

--- a/src/main/java/ac/grim/grimac/utils/math/GrimMath.java
+++ b/src/main/java/ac/grim/grimac/utils/math/GrimMath.java
@@ -111,4 +111,31 @@ public class GrimMath {
         l = l * l * 42317861L + l * 11L;
         return l >> 16;
     }
+
+    public static int getSectionCoord(int coord) {
+        return coord >> 4;
+    }
+
+    public static int getSectionCoord(double coord) {
+        return getSectionCoord(GrimMath.floor(coord));
+    }
+
+    public static long asLong(int x, int y, int z) {
+        long l = 0L;
+        l |= ((long)x & 4194303L) << 42;
+        l |= ((long)y & 1048575L) << 0;
+        return l | ((long)z & 4194303L) << 20;
+    }
+
+    public static int unpackX(long packed) {
+        return (int)(packed << 0 >> 42);
+    }
+
+    public static int unpackY(long packed) {
+        return (int)(packed << 44 >> 44);
+    }
+
+    public static int unpackZ(long packed) {
+        return (int)(packed << 22 >> 42);
+    }
 }

--- a/src/main/resources/punishments/en.yml
+++ b/src/main/resources/punishments/en.yml
@@ -66,6 +66,30 @@ Punishments:
       - "5:5 [alert]"
       - "5:5 [webhook]"
       - "5:5 [proxy]"
+  HitboxMiss:
+    remove-violations-after: 300
+    checks:
+      - "HitboxMiss"
+    commands:
+      - "7:5 [alert]"
+      - "7:5 [webhook]"
+      - "7:5 [proxy]"
+  HitboxBlock:
+    remove-violations-after: 300
+    checks:
+      - "HitboxBlock"
+    commands:
+      - "10:5 [alert]"
+      - "10:5 [webhook]"
+      - "10:5 [proxy]"
+  HitboxEntity:
+    remove-violations-after: 300
+    checks:
+      - "HitboxEntity"
+    commands:
+      - "15:10 [alert]"
+      - "15:10 [webhook]"
+      - "15:10 [proxy]"
   Misc:
     remove-violations-after: 300
     checks:


### PR DESCRIPTION
We now replicate vanilla entity iteration order, reducing the amount of falses that happen when checking if a player hit an entity through another entity, especially in swarms/group fights.