### PR TITLE
Fix incorrect path to the jar.

### DIFF
--- a/.github/workflows/gradle-publish.yml
+++ b/.github/workflows/gradle-publish.yml
@@ -17,22 +17,23 @@ jobs:
     permissions:
       contents: read
       packages: write
+      actions: write
 
     steps:
-    - uses: actions/checkout@v4
-    - name: Set up JDK 17
-      uses: actions/setup-java@v4
-      with:
-        java-version: '17'
-        distribution: 'temurin'
-        server-id: github # Value of the distributionManagement/repository/id field of the pom.xml
-        settings-path: ${{ github.workspace }} # location for the settings.xml file
+      - uses: actions/checkout@v4
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          server-id: github # Value of the distributionManagement/repository/id field of the pom.xml
+          settings-path: ${{ github.workspace }} # location for the settings.xml file
 
-    - name: Build with Gradle
-      uses: gradle/actions/setup-gradle@v3
-      with:
-        arguments: build
-    - name: Upload a Build Artifact
-      uses: actions/upload-artifact@v4
-      with:
-        path: /home/runner/work/Grim/Grim/build/libs/**.jar
+      - name: Build with Gradle
+        uses: gradle/actions/setup-gradle@v3
+        with:
+          arguments: build
+      - name: Upload a Build Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          path: build/libs/*.jar


### PR DESCRIPTION
This is my attempt to fix
![image](https://github.com/user-attachments/assets/d0ffaaf4-1c16-4207-b7d6-d5f010faa938)
for actions. Because before it does not provide artifact with grim.jar
