### PR TITLE
Backport storage ownership leases

### DIFF
--- a/buildSrc/src/main/kotlin/exclusive.kt
+++ b/buildSrc/src/main/kotlin/exclusive.kt
@@ -25,18 +25,31 @@ fun RepositoryHandler.exclusive(
 }
 
 fun RepositoryHandler.exclusive(
+    urls: Iterable<String>,
+    filterConfig: InclusiveRepositoryContentDescriptor.() -> Unit
+) {
+    val remotes = urls.map { maven(it) }
+
+    exclusiveRemotes(remotes, filterConfig)
+}
+
+fun RepositoryHandler.exclusive(
     remote: MavenArtifactRepository,
+    filterConfig: InclusiveRepositoryContentDescriptor.() -> Unit
+) {
+    exclusiveRemotes(listOf(remote), filterConfig)
+}
+
+private fun RepositoryHandler.exclusiveRemotes(
+    remotes: Iterable<MavenArtifactRepository>,
     filterConfig: InclusiveRepositoryContentDescriptor.() -> Unit
 ) {
     // We access BuildConfig here again to check for local override
     val local = if (BuildConfig.mavenLocalOverride) mavenLocal() else null
+    val repositories = if (local != null) listOf(local) + remotes else remotes.toList()
 
     exclusiveContent {
-        if (local != null) {
-            forRepositories(local, remote)
-        } else {
-            forRepositories(remote)
-        }
+        forRepositories(*repositories.toTypedArray())
         filter(filterConfig)
     }
 }

--- a/bukkit/build.gradle.kts
+++ b/bukkit/build.gradle.kts
@@ -27,7 +27,7 @@ repositories {
         includeGroup("me.clip")
     }
 
-    exclusive("https://repo.grim.ac/snapshots") {
+    exclusive(listOf("https://repo.grim.ac/releases", "https://repo.grim.ac/snapshots")) {
         includeGroup("ac.grim.grimac")
         includeGroup("com.github.retrooper")
     }

--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -62,6 +62,7 @@ dependencies {
     api(libs.adventure.text.minimessage)
     api(libs.jetbrains.annotations)
     api(libs.hikaricp)
+    compileOnly(libs.mongo.driver.sync)
 
     api(libs.grim.api)
     api(libs.grim.internal)

--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -10,7 +10,7 @@ repositories {
     if (BuildConfig.mavenLocalOverride) mavenLocal()
 
     // Grim API & PacketEvents
-    exclusive("https://repo.grim.ac/snapshots") {
+    exclusive(listOf("https://repo.grim.ac/releases", "https://repo.grim.ac/snapshots")) {
         includeGroup("ac.grim.grimac")
         includeGroup("com.github.retrooper")
     }

--- a/common/src/main/java/ac/grim/grimac/manager/datastore/DataStoreConfigBuilder.java
+++ b/common/src/main/java/ac/grim/grimac/manager/datastore/DataStoreConfigBuilder.java
@@ -8,8 +8,10 @@ import ac.grim.grimac.api.storage.backend.BackendRegistry;
 import ac.grim.grimac.api.storage.category.Categories;
 import ac.grim.grimac.api.storage.category.Category;
 import ac.grim.grimac.api.storage.config.DataStoreConfig;
+import ac.grim.grimac.api.storage.config.DuplicatePersistentUuidAction;
 import ac.grim.grimac.api.storage.config.HistoryConfig;
 import ac.grim.grimac.api.storage.config.MigrationConfig;
+import ac.grim.grimac.api.storage.config.OwnershipConfig;
 import ac.grim.grimac.api.storage.config.RetentionRule;
 import ac.grim.grimac.api.storage.config.SessionConfig;
 import ac.grim.grimac.api.storage.config.WaitStrategyType;
@@ -64,6 +66,8 @@ public final class DataStoreConfigBuilder {
                 config.getBooleanElse(NS + "session.scope-per-server", true),
                 config.getLongElse(NS + "session.heartbeat-interval-ms", 30_000L));
 
+        OwnershipConfig ownership = readOwnership();
+
         WritePathConfig writePath = readWritePath();
         Map<Category<?>, RetentionRule> retention = readRetention();
 
@@ -81,7 +85,31 @@ public final class DataStoreConfigBuilder {
         String serverName = config.getStringElse(NS + "server-name", "Unknown");
 
         return new DataStoreConfig(
-                routing, backends, session, writePath, retention, migration, chain, history, serverName);
+                routing, backends, session, ownership, writePath, retention, migration, chain, history, serverName);
+    }
+
+    private @NotNull OwnershipConfig readOwnership() {
+        String actionRaw = config.getStringElse(
+                NS + "ownership.duplicate-persistent-uuid-action", "disable-storage");
+        DuplicatePersistentUuidAction action;
+        try {
+            action = DuplicatePersistentUuidAction.valueOf(
+                    actionRaw.trim().toUpperCase(Locale.ROOT).replace('-', '_'));
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException(
+                    "database.ownership.duplicate-persistent-uuid-action must be one of "
+                            + "disable-storage, fail-startup, allow-unsafe (got '" + actionRaw + "')");
+        }
+        return new OwnershipConfig(
+                config.getBooleanElse(NS + "ownership.enforce-persistent-uuid-ownership", true),
+                action,
+                config.getLongElse(NS + "ownership.lease-ttl-ms", 20_000L),
+                config.getLongElse(NS + "ownership.renew-interval-ms", 10_000L),
+                config.getLongElse(NS + "ownership.startup-wait-ms", 20_000L),
+                config.getLongElse(NS + "ownership.safety-margin-ms", 5_000L),
+                config.getLongElse(NS + "ownership.stale-startup-ttl-ms", 30_000L),
+                config.getLongElse(NS + "ownership.recovery-sweep-interval-ms", 10_000L),
+                config.getBooleanElse(NS + "ownership.cleanup-other-servers", true));
     }
 
     private Map<Category<?>, String> readRouting() {

--- a/common/src/main/java/ac/grim/grimac/manager/datastore/DataStoreLifecycle.java
+++ b/common/src/main/java/ac/grim/grimac/manager/datastore/DataStoreLifecycle.java
@@ -2,58 +2,102 @@ package ac.grim.grimac.manager.datastore;
 
 import ac.grim.grimac.GrimAPI;
 import ac.grim.grimac.api.plugin.GrimPlugin;
-import ac.grim.grimac.manager.init.start.StartableInitable;
-import ac.grim.grimac.manager.init.stop.StoppableInitable;
 import ac.grim.grimac.api.storage.DataStore;
 import ac.grim.grimac.api.storage.backend.Backend;
 import ac.grim.grimac.api.storage.backend.BackendConfig;
 import ac.grim.grimac.api.storage.backend.BackendContext;
 import ac.grim.grimac.api.storage.backend.BackendException;
-import ac.grim.grimac.api.storage.backend.BackendProvider;
 import ac.grim.grimac.api.storage.backend.BackendRegistry;
+import ac.grim.grimac.api.storage.backend.BackendV2;
 import ac.grim.grimac.api.storage.category.Categories;
 import ac.grim.grimac.api.storage.category.Category;
+import ac.grim.grimac.api.storage.check.CheckCatalogPersistence;
+import ac.grim.grimac.api.storage.check.CheckCatalogRow;
 import ac.grim.grimac.api.storage.config.DataStoreConfig;
+import ac.grim.grimac.api.storage.config.DuplicatePersistentUuidAction;
 import ac.grim.grimac.api.storage.history.HistoryService;
 import ac.grim.grimac.api.storage.identity.NameResolver;
 import ac.grim.grimac.api.storage.identity.NameResolverLink;
+import ac.grim.grimac.api.storage.instance.OwnershipClaimResult;
+import ac.grim.grimac.api.storage.instance.ServerOwnershipAdapter;
+import ac.grim.grimac.api.storage.instance.ServerOwnershipGate;
+import ac.grim.grimac.api.storage.instance.ServerOwnershipMetadata;
+import ac.grim.grimac.api.storage.instance.ServerOwnershipSnapshot;
+import ac.grim.grimac.api.storage.registry.MigrationContext;
+import ac.grim.grimac.api.storage.registry.StoreId;
 import ac.grim.grimac.api.storage.submit.ViolationSink;
+import ac.grim.grimac.internal.storage.backend.mongo.MongoBackendConfig;
+import ac.grim.grimac.internal.storage.backend.mongo.v2.MongoBackendV2;
+import ac.grim.grimac.internal.storage.backend.mongo.v2.MongoMigrationContext;
+import ac.grim.grimac.internal.storage.backend.mysql.MysqlBackendConfig;
+import ac.grim.grimac.internal.storage.backend.mysql.v2.MysqlBackendV2;
+import ac.grim.grimac.internal.storage.backend.postgres.PostgresBackendConfig;
+import ac.grim.grimac.internal.storage.backend.postgres.v2.PostgresBackendV2;
+import ac.grim.grimac.internal.storage.backend.redis.RedisBackendConfig;
+import ac.grim.grimac.internal.storage.backend.redis.v2.RedisBackendV2;
 import ac.grim.grimac.internal.storage.backend.sqlite.SqliteBackend;
+import ac.grim.grimac.internal.storage.backend.sqlite.SqliteBackendConfig;
+import ac.grim.grimac.internal.storage.backend.sqlite.v2.SqliteBackendV2;
+import ac.grim.grimac.internal.storage.category.V2BuiltinKinds;
 import ac.grim.grimac.internal.storage.checks.CheckRegistry;
+import ac.grim.grimac.internal.storage.checks.DataStoreCheckCatalogPersistence;
 import ac.grim.grimac.internal.storage.checks.InMemoryCheckCatalogPersistence;
-import ac.grim.grimac.internal.storage.core.CapabilityValidator;
+import ac.grim.grimac.internal.storage.checks.JdbcCheckCatalogPersistence;
 import ac.grim.grimac.internal.storage.core.CategoryRouter;
 import ac.grim.grimac.internal.storage.core.DataStoreImpl;
+import ac.grim.grimac.internal.storage.core.V2BackendBootstrap;
+import ac.grim.grimac.internal.storage.core.V2Routes;
 import ac.grim.grimac.internal.storage.history.HistoryServiceImpl;
 import ac.grim.grimac.internal.storage.identity.LocalCacheLink;
 import ac.grim.grimac.internal.storage.identity.NameResolverChain;
 import ac.grim.grimac.internal.storage.identity.OfflineModeUuidLink;
 import ac.grim.grimac.internal.storage.identity.PlayerIdentityService;
+import ac.grim.grimac.internal.storage.instance.HeartbeatScheduler;
 import ac.grim.grimac.internal.storage.migrate.LegacyMigrator;
 import ac.grim.grimac.internal.storage.migrate.V0Reader;
 import ac.grim.grimac.internal.storage.retention.RetentionSweeper;
 import ac.grim.grimac.internal.storage.submit.ViolationSinkImpl;
+import ac.grim.grimac.manager.init.start.StartableInitable;
+import ac.grim.grimac.manager.init.stop.StoppableInitable;
+import com.mongodb.client.MongoDatabase;
+import org.bson.BsonBinarySubType;
+import org.bson.Document;
+import org.bson.types.Binary;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import javax.sql.DataSource;
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.nio.file.StandardOpenOption;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.UUID;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
- * Wires the shared DataStore + associated services to the plugin's
- * start/stop lifecycle. Owns the construction order: build backends → init →
- * capability-validate routing → migrate any legacy store → start writer
- * loops → register services. Accepting players happens in
- * {@link GrimAPI#start()} after this.
+ * Wires the shared DataStore and services to the plugin lifecycle. This path
+ * uses the v2 backend primitives so persistent UUID ownership, startup rows,
+ * and crash recovery all share the same backend under the session route.
  */
 public final class DataStoreLifecycle implements StartableInitable, StoppableInitable {
+
+    private static final String CHECKS_STORE = "grim_checks";
+    private static final StoreId OWNERSHIP_STORE = StoreId.grim("server_ownership");
 
     private final GrimPlugin plugin;
     private final Logger logger;
@@ -67,12 +111,25 @@ public final class DataStoreLifecycle implements StartableInitable, StoppableIni
     private NameResolver nameResolver;
     private ViolationSinkImpl violationSink;
     private RetentionSweeper retentionSweeper;
-    private SessionTracker sessionTracker;
-    private LiveWriteHooks liveWriteHooks;
-    private PlayerToggleStore playerToggleStore;
+    private SessionTracker sessionTracker = SessionTracker.NOOP;
+    private LiveWriteHooks liveWriteHooks = LiveWriteHooks.NOOP;
+    private PlayerToggleStore playerToggleStore = PlayerToggleStore.NOOP;
+    private V2InstanceRegistry instanceRegistry;
+    private HeartbeatScheduler heartbeatScheduler;
+    private OwnershipHeartbeatScheduler ownershipHeartbeatScheduler;
+    private ServerOwnershipAdapter ownershipAdapter;
+    private ServerOwnershipGate ownershipGate = ServerOwnershipGate.disabled();
+    private UUID instanceId;
+    private UUID startupId;
+    private UUID ownershipFence;
+    private long startupStartedEpochMs;
+    private ScheduledExecutorService duplicateWarningExecutor;
+    private ScheduledExecutorService recoverySweepExecutor;
 
     private boolean enabled = true;
     private boolean loaded;
+
+    private final List<BackendV2> v2Backends = new ArrayList<>();
 
     public DataStoreLifecycle(@NotNull GrimPlugin plugin, @NotNull BackendRegistry backendRegistry) {
         this.plugin = Objects.requireNonNull(plugin, "plugin");
@@ -83,120 +140,827 @@ public final class DataStoreLifecycle implements StartableInitable, StoppableIni
     @Override
     public void start() {
         Path dataFolder = plugin.getDataFolder().toPath();
-        // database.yml + per-backend files load through the shared
-        // ConfigManager (see ConfigManagerFileImpl). Their key paths are
-        // namespaced under `database:` / `<id>:` wrappers so Configuralize's
-        // flat-merge doesn't collide them with config.yml / discord.yml.
-        // The cross-version updater also runs there before this method is
-        // called, so the on-disk files are already migrated.
         DataStoreConfigBuilder builder = new DataStoreConfigBuilder(
                 backendRegistry,
                 dataFolder,
                 GrimAPI.INSTANCE.getConfigManager().getConfig());
 
         if (!builder.enabled()) {
-            logger.info("[grim-datastore] disabled in database.yml — skipping storage init");
+            logger.info("[grim-datastore] disabled in database.yml - skipping storage init");
             this.enabled = false;
             return;
         }
+        this.enabled = true;
         try {
             this.config = builder.build();
         } catch (RuntimeException e) {
-            logger.log(Level.SEVERE, "[grim-datastore] database.yml rejected — storage disabled", e);
+            logger.log(Level.SEVERE, "[grim-datastore] database.yml rejected - storage disabled", e);
             this.enabled = false;
             return;
         }
 
         try {
-            buildAndStart(dataFolder);
-            this.loaded = true;
-        } catch (Exception e) {
-            logger.log(Level.SEVERE, "[grim-datastore] failed to initialise storage — falling back to disabled", e);
+            this.loaded = buildAndStart(dataFolder);
+        } catch (FatalStorageStartupException e) {
+            logger.log(Level.SEVERE, "[grim-datastore] fatal storage startup failure - shutting down server", e);
+            try { close(); } catch (Exception ignore) {}
             this.enabled = false;
-            try { teardown(); } catch (Exception ignore) {}
+            shutdownServerAfterFatalStorageStartup();
+        } catch (Exception | LinkageError e) {
+            logger.log(Level.SEVERE, "[grim-datastore] failed to initialise storage - falling back to disabled", e);
+            try { close(); } catch (Exception ignore) {}
+            this.enabled = false;
         }
     }
 
-    private void buildAndStart(Path dataFolder) throws Exception {
-        Map<String, Backend> backendsById = new LinkedHashMap<>();
+    private boolean buildAndStart(Path dataFolder) throws Exception {
+        V2Routes.Builder routesBuilder = V2Routes.builder();
+        int allFailures = 0;
+
+        Map<String, BackendV2> v2ById = new LinkedHashMap<>();
         for (Map.Entry<String, BackendConfig> entry : config.backends().entrySet()) {
-            Backend b = buildBackend(entry.getKey(), entry.getValue());
-            b.init(new SimpleContext(entry.getValue(), logger, dataFolder));
-            backendsById.put(entry.getKey(), b);
-        }
-
-        Map<Category<?>, Backend> routing = new LinkedHashMap<>();
-        for (Map.Entry<Category<?>, String> r : config.routing().entrySet()) {
-            Backend b = backendsById.get(r.getValue());
-            if (b == null) continue; // routing target was "none" or an unknown id — skip this category
-            routing.put(r.getKey(), b);
-        }
-
-        CapabilityValidator.validate(routing);
-
-        Backend violationBackend = routing.get(Categories.VIOLATION);
-        if (violationBackend != null) {
-            this.checkRegistry = new CheckRegistry(violationBackend.checkCatalog());
-        } else {
-            this.checkRegistry = new CheckRegistry(new InMemoryCheckCatalogPersistence());
-        }
-        this.checkRegistry.reload();
-
-        SqliteBackend sqliteMigrationTarget = violationBackend instanceof SqliteBackend s ? s : null;
-        maybeMigrateLegacy(dataFolder, sqliteMigrationTarget);
-
-        CategoryRouter router = new CategoryRouter(routing);
-        this.dataStore = new DataStoreImpl(router, config.writePath(), logger);
-        this.dataStore.start();
-
-        this.historyService = new HistoryServiceImpl(dataStore, checkRegistry,
-                config.history().entriesPerPage(), config.history().groupIntervalMs());
-        this.playerIdentityService = new PlayerIdentityService(dataStore);
-        this.nameResolver = buildNameResolver(dataStore, config.nameResolutionChain());
-        this.violationSink = new ViolationSinkImpl(dataStore);
-        this.retentionSweeper = new RetentionSweeper(dataStore, config.retention(), logger);
-        this.sessionTracker = new SessionTrackerImpl(
-                dataStore, config.serverName(), config.session().heartbeatIntervalMs());
-        this.liveWriteHooks = new LiveWriteHooksImpl(
-                dataStore, playerIdentityService, checkRegistry, sessionTracker);
-        this.playerToggleStore = new PlayerToggleStoreImpl(dataStore, logger);
-
-        // Crash sweep — mark every session whose closed_at is still null as
-        // crashed by stamping closed_at = last_activity. SessionTracker has
-        // no in-memory state at this point (we're pre-first-join), so any
-        // open row is by definition orphaned. Per-backend implementations
-        // do this in one UPDATE; default no-op for backends without a
-        // session table.
-        for (Backend b : router.allBackends()) {
+            String backendId = entry.getKey();
+            BackendConfig backendConfig = entry.getValue();
+            BackendV2 v2 = constructV2Direct(backendId, backendConfig);
+            if (v2 == null) {
+                logger.warning("[grim-datastore] no v2 backend for id '" + backendId
+                        + "' - categories routed here will be unavailable");
+                continue;
+            }
             try {
-                long affected = b.markCrashedSessions();
-                if (affected > 0) {
-                    logger.info("[grim-datastore] marked " + affected
-                            + " open session(s) on backend '" + b.id()
-                            + "' as crashed (server didn't shut down cleanly last run)");
-                }
+                v2.init(new SimpleContext(backendConfig, logger, dataFolder));
             } catch (Exception e) {
-                logger.log(Level.WARNING,
-                        "[grim-datastore] markCrashedSessions failed on backend '"
-                                + b.id() + "' — sessions may show as ongoing forever", e);
+                logger.log(Level.SEVERE,
+                        "[grim-datastore] v2 backend init failed for '" + backendId + "'", e);
+                try { v2.close(); }
+                catch (Exception closeFailure) {
+                    logger.log(Level.WARNING,
+                            "[grim-datastore] v2 backend close after failed init failed for '"
+                                    + backendId + "'", closeFailure);
+                }
+                continue;
+            }
+            this.v2Backends.add(v2);
+            v2ById.put(backendId, v2);
+        }
+
+        for (Map.Entry<Category<?>, String> r : config.routing().entrySet()) {
+            Category<?> cat = r.getKey();
+            String backendId = r.getValue();
+            if ("none".equals(backendId)) continue;
+            BackendV2 v2 = v2ById.get(backendId);
+            if (v2 == null) continue;
+
+            Map<Category<?>, V2BackendBootstrap.Binding<?>> bindings = bindingsForCategory(cat);
+            if (bindings.isEmpty()) continue;
+
+            MigrationContext mctx = buildMigrationContext(v2);
+            if (mctx == null) mctx = NO_OP_MIGRATION_CONTEXT;
+
+            V2BackendBootstrap.Result result = V2BackendBootstrap.install(
+                    bindings, v2, mctx, routesBuilder, logger);
+            allFailures += result.failures().size();
+            if (!result.ok()) {
+                logger.warning("[grim-datastore] v2 bootstrap for '" + backendId
+                        + "' had " + result.failures().size() + " failure(s):\n  - "
+                        + String.join("\n  - ", result.failures()));
+            }
+        }
+
+        boolean startupRouteInstalled = false;
+        String sessionBackendId = config.routing().get(Categories.SESSION);
+        if (sessionBackendId != null && !"none".equals(sessionBackendId)) {
+            BackendV2 sessionBackend = v2ById.get(sessionBackendId);
+            if (sessionBackend != null) {
+                this.ownershipAdapter = sessionBackend.ownershipAdapter().orElse(null);
+                if (ownershipAdapter != null) {
+                    try {
+                        ownershipAdapter.ensureStore(OWNERSHIP_STORE);
+                    } catch (Exception e) {
+                        allFailures++;
+                        logger.log(Level.WARNING,
+                                "[grim-datastore] failed to ensure server ownership store on '"
+                                        + sessionBackendId + "'", e);
+                    }
+                }
+                MigrationContext mctx = buildMigrationContext(sessionBackend);
+                if (mctx == null) mctx = NO_OP_MIGRATION_CONTEXT;
+
+                Map<Category<?>, V2BackendBootstrap.Binding<?>> bindings = Map.of(
+                        V2InstanceRegistry.STARTUPS,
+                        new V2BackendBootstrap.Binding<>(
+                                StoreId.grim("server_startups"), V2BuiltinKinds.serverStartups()));
+                V2BackendBootstrap.Result result = V2BackendBootstrap.install(
+                        bindings, sessionBackend, mctx, routesBuilder, logger);
+                allFailures += result.failures().size();
+                if (result.ok()) {
+                    startupRouteInstalled = true;
+                } else {
+                    logger.warning("[grim-datastore] v2 bootstrap for server startup registry on '"
+                            + sessionBackendId + "' had " + result.failures().size() + " failure(s):\n  - "
+                            + String.join("\n  - ", result.failures()));
+                }
+            }
+        }
+
+        if (allFailures > 0) {
+            logger.warning("[grim-datastore] v2 cutover skipped " + allFailures
+                    + " failed route(s); continuing with successfully installed routes");
+        }
+
+        V2Routes routes = routesBuilder.build();
+        if (routes.isEmpty()) {
+            throw new RuntimeException("no v2 routes installed");
+        }
+
+        CategoryRouter router = startupRouteInstalled
+                ? new CategoryRouter(Map.of(V2InstanceRegistry.STARTUPS, V2InstanceRegistry.ROUTER_SENTINEL_BACKEND))
+                : new CategoryRouter(Map.of());
+        boolean enforceOwnership = config.ownership().enforcePersistentUuidOwnership()
+                && config.ownership().duplicatePersistentUuidAction() != DuplicatePersistentUuidAction.ALLOW_UNSAFE;
+        this.ownershipGate = new ServerOwnershipGate(enforceOwnership);
+        this.dataStore = new DataStoreImpl(router, config.writePath(), logger);
+        this.dataStore.withV2Routes(routes);
+        this.dataStore.withOwnershipGate(ownershipGate);
+        this.dataStore.start();
+        this.checkRegistry = buildCheckRegistry(v2ById);
+
+        logger.info("[grim-datastore] v2 cutover complete: " + v2ById.size()
+                + " v2 backend(s), " + routes + " routes installed, 0 legacy backends");
+
+        if (!buildServices(routes)) {
+            disableStorageAfterDuplicate();
+            return false;
+        }
+        return true;
+    }
+
+    private @NotNull CheckRegistry buildCheckRegistry(@NotNull Map<String, BackendV2> v2ById) {
+        String backendId = config.routing().get(Categories.VIOLATION);
+        BackendConfig backendConfig = backendId == null ? null : config.backends().get(backendId);
+        BackendV2 backend = backendId == null ? null : v2ById.get(backendId);
+        if (backend == null || !dataStore.v2Routes().contains(Categories.CHECK_CATALOG)) {
+            logger.warning("[grim-datastore] no routed check catalog available for v2 backend '"
+                    + backendId + "' - check names will be process-local only");
+            CheckRegistry fallback = new CheckRegistry(new InMemoryCheckCatalogPersistence());
+            fallback.reload();
+            return fallback;
+        }
+
+        List<CheckCatalogRow> initialRows;
+        try {
+            initialRows = loadExistingCheckCatalogRows(backend, backendConfig);
+        } catch (RuntimeException e) {
+            logger.log(Level.WARNING,
+                    "[grim-datastore] failed to load persisted check catalog for backend '"
+                            + backendId + "' - falling back to process-local check names", e);
+            CheckRegistry fallback = new CheckRegistry(new InMemoryCheckCatalogPersistence());
+            fallback.reload();
+            return fallback;
+        }
+
+        CheckCatalogPersistence persistence =
+                new DataStoreCheckCatalogPersistence(initialRows, dataStore, logger);
+        CheckRegistry registry = new CheckRegistry(persistence);
+        registry.reload();
+        return registry;
+    }
+
+    private @NotNull List<CheckCatalogRow> loadExistingCheckCatalogRows(
+            @NotNull BackendV2 backend,
+            @Nullable BackendConfig backendConfig) {
+        DataSource dataSource = backend.unwrap(DataSource.class).orElse(null);
+        if (dataSource != null) {
+            return rowsFrom(new JdbcCheckCatalogPersistence(dataSource::getConnection, CHECKS_STORE).loadAll());
+        }
+
+        MongoDatabase mongo = backend.unwrap(MongoDatabase.class).orElse(null);
+        if (mongo != null) {
+            List<CheckCatalogRow> out = new ArrayList<>();
+            for (Document d : mongo.getCollection(CHECKS_STORE).find()) {
+                CheckCatalogRow row = checkCatalogRowFromDocument(d);
+                if (row != null) out.add(row);
+            }
+            return out;
+        }
+
+        if (backendConfig instanceof RedisBackendConfig redisConfig) {
+            List<CheckCatalogRow> rows = loadRedisCheckCatalogRows(backend, redisConfig.keyPrefix());
+            if (rows != null) return rows;
+        }
+
+        logger.warning("[grim-datastore] no persisted check catalog loader available for v2 backend '"
+                + backend.id() + "' - starting with an empty routed catalog view");
+        return List.of();
+    }
+
+    private static @NotNull List<CheckCatalogRow> rowsFrom(@NotNull Iterable<CheckCatalogRow> rows) {
+        List<CheckCatalogRow> out = new ArrayList<>();
+        rows.forEach(out::add);
+        return out;
+    }
+
+    private static @Nullable CheckCatalogRow checkCatalogRowFromDocument(@NotNull Document d) {
+        Number id = d.get("check_id", Number.class);
+        String stableKey = d.getString("stable_key");
+        if (stableKey == null) {
+            Object rawId = d.get("_id");
+            if (rawId instanceof String s) stableKey = s;
+        }
+        if (id == null || stableKey == null) return null;
+        Number introducedAt = d.get("introduced_at", Number.class);
+        return new CheckCatalogRow(
+                id.intValue(),
+                stableKey,
+                d.getString("display"),
+                d.getString("description"),
+                d.getString("introduced_version"),
+                introducedAt == null ? 0L : introducedAt.longValue());
+    }
+
+    @SuppressWarnings("unchecked")
+    private static @Nullable List<CheckCatalogRow> loadRedisCheckCatalogRows(
+            @NotNull BackendV2 backend,
+            @NotNull String keyPrefix) {
+        try {
+            Class<?> poolClass = Class.forName("redis.clients.jedis.JedisPool");
+            Object pool = backend.unwrap((Class<Object>) poolClass).orElse(null);
+            if (pool == null) return null;
+
+            Class<?> scanParamsClass = Class.forName("redis.clients.jedis.params.ScanParams");
+            Object params = scanParamsClass.getConstructor().newInstance();
+            String rowPrefix = keyPrefix + CHECKS_STORE + ":";
+            scanParamsClass.getMethod("match", String.class).invoke(params, rowPrefix + "*");
+            scanParamsClass.getMethod("count", int.class).invoke(params, 1000);
+
+            List<CheckCatalogRow> out = new ArrayList<>();
+            Object jedis = poolClass.getMethod("getResource").invoke(pool);
+            try {
+                String cursor = "0";
+                do {
+                    Object result = jedis.getClass()
+                            .getMethod("scan", String.class, scanParamsClass)
+                            .invoke(jedis, cursor, params);
+                    List<String> keys = (List<String>) result.getClass()
+                            .getMethod("getResult")
+                            .invoke(result);
+                    for (String key : keys) {
+                        if (key.startsWith(rowPrefix + "__idx:")) continue;
+                        Map<String, String> hash = (Map<String, String>) jedis.getClass()
+                                .getMethod("hgetAll", String.class)
+                                .invoke(jedis, key);
+                        CheckCatalogRow row = checkCatalogRowFromRedis(hash);
+                        if (row != null) out.add(row);
+                    }
+                    cursor = (String) result.getClass().getMethod("getCursor").invoke(result);
+                } while (!"0".equals(cursor));
+            } finally {
+                if (jedis instanceof AutoCloseable closeable) closeable.close();
+            }
+            return out;
+        } catch (ClassNotFoundException e) {
+            return null;
+        } catch (ReflectiveOperationException e) {
+            throw new IllegalStateException("failed to scan Redis check catalog", e);
+        } catch (Exception e) {
+            throw new IllegalStateException("failed to close Redis resource while scanning check catalog", e);
+        }
+    }
+
+    private static @Nullable CheckCatalogRow checkCatalogRowFromRedis(@NotNull Map<String, String> h) {
+        String id = h.get("check_id");
+        String stableKey = h.get("stable_key");
+        if (id == null || stableKey == null) return null;
+        return new CheckCatalogRow(
+                Integer.parseInt(id),
+                stableKey,
+                h.get("display"),
+                h.get("description"),
+                h.get("introduced_version"),
+                parseLong(h.get("introduced_at")));
+    }
+
+    private static long parseLong(@Nullable String raw) {
+        if (raw == null) return 0L;
+        try {
+            return Long.parseLong(raw);
+        } catch (NumberFormatException ignored) {
+            return 0L;
+        }
+    }
+
+    private @Nullable BackendV2 constructV2Direct(@NotNull String backendId,
+                                                  @NotNull BackendConfig config) {
+        return switch (backendId) {
+            case "mongo" -> config instanceof MongoBackendConfig c ? new MongoBackendV2(c) : null;
+            case "postgres" -> config instanceof PostgresBackendConfig c ? new PostgresBackendV2(c) : null;
+            case "mysql" -> config instanceof MysqlBackendConfig c ? new MysqlBackendV2(c) : null;
+            case "sqlite" -> config instanceof SqliteBackendConfig c ? new SqliteBackendV2(c) : null;
+            case "redis" -> config instanceof RedisBackendConfig c ? new RedisBackendV2(c) : null;
+            default -> null;
+        };
+    }
+
+    private @NotNull Map<Category<?>, V2BackendBootstrap.Binding<?>> bindingsForCategory(
+            @NotNull Category<?> cat) {
+        Map<Category<?>, V2BackendBootstrap.Binding<?>> out = new LinkedHashMap<>();
+        if (cat == Categories.VIOLATION) {
+            out.put(cat, new V2BackendBootstrap.Binding<>(
+                    StoreId.grim("grim_violations"), V2BuiltinKinds.violations()));
+            out.put(Categories.CHECK_CATALOG, new V2BackendBootstrap.Binding<>(
+                    StoreId.grim(CHECKS_STORE), V2BuiltinKinds.checks()));
+        } else if (cat == Categories.SESSION) {
+            out.put(cat, new V2BackendBootstrap.Binding<>(
+                    StoreId.grim("grim_sessions"), V2BuiltinKinds.sessions()));
+        } else if (cat == Categories.PLAYER_IDENTITY) {
+            out.put(cat, new V2BackendBootstrap.Binding<>(
+                    StoreId.grim("grim_players"), V2BuiltinKinds.players()));
+        } else if (cat == Categories.SETTING) {
+            out.put(cat, new V2BackendBootstrap.Binding<>(
+                    StoreId.grim("grim_settings"), V2BuiltinKinds.settings()));
+        }
+        return out;
+    }
+
+    private boolean buildServices(@NotNull V2Routes routes) {
+        V2InstanceRegistry.StartupClaim claim = startInstanceRegistry();
+        if (claim != null && claim.duplicate()) {
+            startDuplicateWarning(claim.warningMessage());
+            return false;
+        }
+
+        boolean sessionRouted = routes.contains(Categories.SESSION);
+        boolean violationRouted = routes.contains(Categories.VIOLATION);
+        boolean playerIdentityRouted = routes.contains(Categories.PLAYER_IDENTITY);
+        boolean settingRouted = routes.contains(Categories.SETTING);
+
+        if (sessionRouted && violationRouted) {
+            this.historyService = new HistoryServiceImpl(dataStore, checkRegistry,
+                    config.history().entriesPerPage(), config.history().groupIntervalMs())
+                    .withV2Startups(Categories.SERVER_STARTUP);
+        } else {
+            logger.warning("[grim-datastore] history disabled; missing "
+                    + missingRoutes(sessionRouted, "session", violationRouted, "violation"));
+        }
+        this.playerIdentityService = new PlayerIdentityService(dataStore);
+        this.nameResolver = buildNameResolver(dataStore, config.nameResolutionChain(), playerIdentityRouted);
+        this.violationSink = violationRouted ? new ViolationSinkImpl(dataStore) : null;
+        this.retentionSweeper = new RetentionSweeper(dataStore, config.retention(), logger);
+        if (sessionRouted) {
+            this.sessionTracker = new SessionTrackerImpl(
+                    dataStore, config.serverName(), config.session().heartbeatIntervalMs(), startupId);
+        } else {
+            this.sessionTracker = SessionTracker.NOOP;
+            logger.warning("[grim-datastore] session tracking disabled; missing session route");
+        }
+        if (sessionRouted && violationRouted) {
+            this.liveWriteHooks = new LiveWriteHooksImpl(
+                    dataStore, playerIdentityService, checkRegistry, sessionTracker);
+        } else if (playerIdentityRouted) {
+            this.liveWriteHooks = new IdentityLiveWriteHooks(playerIdentityService);
+        } else {
+            this.liveWriteHooks = LiveWriteHooks.NOOP;
+        }
+        if (settingRouted) {
+            this.playerToggleStore = new PlayerToggleStoreImpl(dataStore, logger);
+        } else {
+            this.playerToggleStore = PlayerToggleStore.NOOP;
+            logger.warning("[grim-datastore] player toggle persistence disabled; missing setting route");
+        }
+        return true;
+    }
+
+    private static @NotNull String missingRoutes(
+            boolean firstPresent, @NotNull String first,
+            boolean secondPresent, @NotNull String second) {
+        if (!firstPresent && !secondPresent) return first + " and " + second + " routes";
+        if (!firstPresent) return first + " route";
+        return second + " route";
+    }
+
+    private @Nullable V2InstanceRegistry.StartupClaim startInstanceRegistry() {
+        long heartbeatMs = ownershipGate.enforced()
+                ? config.ownership().renewIntervalMs()
+                : instanceHeartbeatIntervalMs();
+        long leaseTtlMs = config.ownership().leaseTtlMs();
+        this.instanceId = loadPersistentInstanceId(plugin.getDataFolder().toPath());
+        this.startupId = UUID.randomUUID();
+        this.ownershipFence = UUID.randomUUID();
+        this.startupStartedEpochMs = System.currentTimeMillis();
+
+        this.instanceRegistry = V2InstanceRegistry.create(dataStore, dataStore.v2Routes(), logger);
+        if (instanceRegistry == null) {
+            String message = "[grim-datastore] v2 server startup registry route missing; "
+                    + "startup history and crash recovery are disabled";
+            logger.warning(message);
+            if (ownershipGate.enforced()) {
+                return ownershipDenied(message, null, -1L);
+            }
+            return null;
+        }
+
+        ServerOwnershipMetadata metadata = new ServerOwnershipMetadata(
+                config.serverName(),
+                hostname(),
+                GrimAPI.INSTANCE.getExternalAPI().getGrimVersion(),
+                GrimAPI.INSTANCE.getPlatformServer().getPlatformImplementationString());
+
+        boolean enforceOwnership = ownershipGate.enforced();
+        OwnershipClaimResult ownershipClaim = null;
+        if (enforceOwnership) {
+            if (ownershipAdapter == null) {
+                String message = "[grim-datastore] STORAGE DISABLED: backend for sessions does not expose "
+                        + "a server ownership adapter, but persistent UUID ownership is enforced.";
+                return ownershipDenied(message, null, -1L);
+            }
+            ownershipClaim = claimOwnershipWithOptionalWait(metadata);
+            if (!ownershipClaim.claimed()) {
+                ServerOwnershipSnapshot owner = ownershipClaim.currentOwner();
+                long remaining = owner == null ? -1L
+                        : Math.max(0L, owner.leaseExpiresAtEpochMs() - ownershipClaim.dbNowEpochMs());
+                String message = "[grim-datastore] STORAGE DISABLED: live duplicate persistent storage UUID "
+                        + instanceId + " detected. Existing startupId="
+                        + (owner == null ? "unknown" : owner.ownerStartupId())
+                        + " serverName='" + (owner == null ? "unknown" : owner.serverName()) + "'"
+                        + " leaseRemainingMs=" + remaining
+                        + "; this startupId=" + startupId
+                        + ". A server data folder or storage-instance.uuid appears to be copied.";
+                return ownershipDenied(message, owner == null ? null : owner.ownerStartupId(), remaining);
+            }
+            ownershipGate.open(startupId, ownershipFence, leaseTtlMs, config.ownership().safetyMarginMs());
+        }
+
+        long dbNow = ownershipClaim != null
+                ? ownershipClaim.dbNowEpochMs()
+                : dbNowBestEffort();
+        V2InstanceRegistry.StartupClaim claim = instanceRegistry.openStartup(
+                config.serverName(),
+                instanceId,
+                startupId,
+                ownershipFence,
+                startupStartedEpochMs,
+                dbNow,
+                metadata.hostname(),
+                metadata.grimVersion(),
+                metadata.serverVersionString(),
+                null);
+
+        long recovered = recoverAfterStartupClaim(ownershipClaim, dbNow);
+        if (recovered > 0) {
+            logger.warning("[grim-datastore] recovered " + recovered
+                    + " open session(s) after claiming storage startup");
+        }
+
+        if (enforceOwnership) {
+            this.ownershipHeartbeatScheduler = new OwnershipHeartbeatScheduler(
+                    ownershipAdapter,
+                    OWNERSHIP_STORE,
+                    startupId,
+                    instanceId,
+                    ownershipFence,
+                    config.serverName(),
+                    startupStartedEpochMs,
+                    metadata.hostname(),
+                    metadata.grimVersion(),
+                    metadata.serverVersionString(),
+                    () -> null,
+                    leaseTtlMs,
+                    config.ownership().safetyMarginMs(),
+                    Duration.ofMillis(heartbeatMs),
+                    ownershipGate,
+                    instanceRegistry::publish,
+                    this::disablePersistenceAfterLostOwnership,
+                    logger);
+            ownershipHeartbeatScheduler.start();
+        } else {
+            this.heartbeatScheduler = new HeartbeatScheduler(
+                    startupId,
+                    instanceId,
+                    config.serverName(),
+                    startupStartedEpochMs,
+                    metadata.hostname(),
+                    metadata.grimVersion(),
+                    metadata.serverVersionString(),
+                    () -> null,
+                    Duration.ofMillis(heartbeatMs),
+                    instanceRegistry::publish,
+                    logger);
+            heartbeatScheduler.start();
+        }
+        startRecoverySweep();
+        return claim;
+    }
+
+    private @NotNull OwnershipClaimResult claimOwnershipWithOptionalWait(
+            @NotNull ServerOwnershipMetadata metadata) {
+        long ttlMs = config.ownership().leaseTtlMs();
+        OwnershipClaimResult first = claimOwnership(metadata, ttlMs);
+        if (first.claimed()) return first;
+        ServerOwnershipSnapshot owner = first.currentOwner();
+        long remaining = owner == null ? 0L
+                : Math.max(0L, owner.leaseExpiresAtEpochMs() - first.dbNowEpochMs());
+        long waitMs = Math.min(config.ownership().startupWaitMs(), remaining + 50L);
+        if (waitMs <= 0L || owner == null) return first;
+        logger.warning("[grim-datastore] persistent storage UUID " + instanceId
+                + " is owned by startupId=" + owner.ownerStartupId()
+                + "; waiting " + waitMs + "ms for the ownership lease to expire before retrying");
+        try {
+            Thread.sleep(waitMs);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            return first;
+        }
+        return claimOwnership(metadata, ttlMs);
+    }
+
+    private @NotNull OwnershipClaimResult claimOwnership(
+            @NotNull ServerOwnershipMetadata metadata,
+            long ttlMs) {
+        try {
+            return ownershipAdapter.claimOwnership(
+                    OWNERSHIP_STORE, instanceId, startupId, ownershipFence, ttlMs, metadata);
+        } catch (Exception e) {
+            throw new RuntimeException("failed to claim server ownership", e);
+        }
+    }
+
+    private @Nullable V2InstanceRegistry.StartupClaim ownershipDenied(
+            @NotNull String message,
+            @Nullable UUID conflictingStartupId,
+            long leaseRemainingMs) {
+        if (config.ownership().duplicatePersistentUuidAction() == DuplicatePersistentUuidAction.FAIL_STARTUP) {
+            throw new FatalStorageStartupException(message);
+        }
+        logger.warning(message);
+        ownershipGate.close("duplicate-persistent-uuid");
+        return V2InstanceRegistry.StartupClaim.duplicate(
+                startupId, instanceId,
+                conflictingStartupId == null ? startupId : conflictingStartupId,
+                leaseRemainingMs,
+                message);
+    }
+
+    private void shutdownServerAfterFatalStorageStartup() {
+        Runnable stop = () -> GrimAPI.INSTANCE.getPlatformServer().dispatchCommand(
+                GrimAPI.INSTANCE.getPlatformServer().getConsoleSender(),
+                "stop");
+        try {
+            GrimAPI.INSTANCE.getScheduler().getGlobalRegionScheduler().run(plugin, stop);
+        } catch (RuntimeException e) {
+            logger.log(Level.SEVERE, "[grim-datastore] failed to schedule server shutdown after fatal storage startup", e);
+            try {
+                stop.run();
+            } catch (RuntimeException immediateFailure) {
+                logger.log(Level.SEVERE, "[grim-datastore] failed to dispatch stop command after fatal storage startup", immediateFailure);
             }
         }
     }
 
-    private Backend buildBackend(String id, BackendConfig cfg) {
-        BackendProvider provider = backendRegistry.lookup(id);
-        if (provider == null) {
-            throw new IllegalArgumentException("no backend provider registered for id '" + id
-                    + "' (registered: " + backendRegistry.registeredIds() + ")");
+    private static final class FatalStorageStartupException extends RuntimeException {
+        FatalStorageStartupException(@NotNull String message) {
+            super(message);
         }
-        return provider.create(cfg);
     }
 
-    private NameResolver buildNameResolver(DataStore store, List<String> chain) {
+    private long recoverAfterStartupClaim(
+            @Nullable OwnershipClaimResult ownershipClaim,
+            long dbNow) {
+        long closed = 0L;
+        if (ownershipClaim != null && ownershipClaim.previousOwner() != null) {
+            ServerOwnershipSnapshot previous = ownershipClaim.previousOwner();
+            if (!startupId.equals(previous.ownerStartupId())
+                    && (previous.closedAtEpochMs() != ServerOwnershipSnapshot.OPEN
+                    || previous.leaseExpiresAtEpochMs() <= dbNow)) {
+                closed += instanceRegistry.recoverStartup(previous.ownerStartupId(), "expired-ownership");
+            }
+        }
+        if (config.ownership().cleanupOtherServers()) {
+            closed += instanceRegistry.recoverStaleStartups(
+                    startupId, dbNow, config.ownership().staleStartupTtlMs());
+        }
+        return closed;
+    }
+
+    private long dbNowBestEffort() {
+        if (ownershipAdapter != null) {
+            try {
+                return ownershipAdapter.dbNowEpochMs();
+            } catch (Exception e) {
+                logger.log(Level.FINE, "[grim-datastore] failed to read DB time; using local time", e);
+            }
+        }
+        return System.currentTimeMillis();
+    }
+
+    private void startRecoverySweep() {
+        if (!config.ownership().cleanupOtherServers() || instanceRegistry == null || startupId == null) return;
+        stopRecoverySweep();
+        recoverySweepExecutor = Executors.newSingleThreadScheduledExecutor(r -> {
+            Thread t = new Thread(r, "grim-storage-recovery-sweep");
+            t.setDaemon(true);
+            return t;
+        });
+        long intervalMs = config.ownership().recoverySweepIntervalMs();
+        recoverySweepExecutor.scheduleAtFixedRate(
+                this::runRecoverySweep,
+                intervalMs,
+                intervalMs,
+                TimeUnit.MILLISECONDS);
+    }
+
+    private void runRecoverySweep() {
+        V2InstanceRegistry registry = instanceRegistry;
+        UUID currentStartup = startupId;
+        if (registry == null || currentStartup == null) return;
+        if (ownershipGate.enforced() && !ownershipGate.allowWrites()) return;
+        try {
+            long closed = registry.recoverStaleStartups(
+                    currentStartup,
+                    dbNowBestEffort(),
+                    config.ownership().staleStartupTtlMs());
+            if (closed > 0) {
+                logger.warning("[grim-datastore] recovery sweep closed " + closed
+                        + " open session(s) from stale startup rows");
+            }
+        } catch (RuntimeException e) {
+            logger.log(Level.WARNING, "[grim-datastore] recovery sweep failed", e);
+        }
+    }
+
+    private void stopRecoverySweep() {
+        if (recoverySweepExecutor != null) {
+            recoverySweepExecutor.shutdownNow();
+            recoverySweepExecutor = null;
+        }
+    }
+
+    private long instanceHeartbeatIntervalMs() {
+        long configured = config.session().heartbeatIntervalMs();
+        return configured > 0L ? configured : 30_000L;
+    }
+
+    private @NotNull UUID loadPersistentInstanceId(@NotNull Path dataFolder) {
+        Path file = dataFolder.resolve("data").resolve("storage-instance.uuid");
+        try {
+            Files.createDirectories(file.getParent());
+            if (Files.exists(file)) {
+                String raw = Files.readString(file, StandardCharsets.UTF_8).trim();
+                try {
+                    return UUID.fromString(raw);
+                } catch (IllegalArgumentException e) {
+                    Path backup = file.resolveSibling(file.getFileName() + ".invalid-" + System.currentTimeMillis());
+                    Files.move(file, backup, StandardCopyOption.REPLACE_EXISTING);
+                    logger.warning("[grim-datastore] invalid storage instance UUID in " + file
+                            + "; moved it to " + backup + " and generated a new persistent id");
+                }
+            }
+
+            UUID generated = UUID.randomUUID();
+            Files.writeString(
+                    file,
+                    generated + System.lineSeparator(),
+                    StandardCharsets.UTF_8,
+                    StandardOpenOption.CREATE_NEW);
+            return generated;
+        } catch (IOException e) {
+            throw new IllegalStateException("failed to load persistent storage instance id from " + file, e);
+        }
+    }
+
+    private void disableStorageAfterDuplicate() {
+        logger.warning("[grim-datastore] storage disabled for this boot because another live Grim startup "
+                + "is using this storage instance id. Runtime checks remain active.");
+        if (heartbeatScheduler != null) {
+            heartbeatScheduler.stop();
+            heartbeatScheduler = null;
+        }
+        if (ownershipHeartbeatScheduler != null) {
+            ownershipHeartbeatScheduler.stop();
+            ownershipHeartbeatScheduler = null;
+        }
+        ownershipGate.close("duplicate-persistent-uuid");
+        if (dataStore != null) {
+            dataStore.flushAndClose(config.writePath().shutdownDrainTimeoutMs());
+        }
+        closeV2Backends();
+        dataStore = null;
+        historyService = null;
+        playerIdentityService = null;
+        nameResolver = null;
+        violationSink = null;
+        retentionSweeper = null;
+        sessionTracker = SessionTracker.NOOP;
+        liveWriteHooks = LiveWriteHooks.NOOP;
+        playerToggleStore = PlayerToggleStore.NOOP;
+        instanceRegistry = null;
+        ownershipAdapter = null;
+        ownershipFence = null;
+        ownershipGate = ServerOwnershipGate.disabled();
+        loaded = false;
+        enabled = false;
+    }
+
+    private void startDuplicateWarning(@NotNull String message) {
+        stopDuplicateWarning();
+        logger.warning(message);
+        duplicateWarningExecutor = Executors.newSingleThreadScheduledExecutor(r -> {
+            Thread t = new Thread(r, "grim-storage-duplicate-warning");
+            t.setDaemon(true);
+            return t;
+        });
+        duplicateWarningExecutor.scheduleAtFixedRate(
+                () -> logger.warning(message),
+                60L,
+                60L,
+                TimeUnit.SECONDS);
+    }
+
+    private void stopDuplicateWarning() {
+        if (duplicateWarningExecutor != null) {
+            duplicateWarningExecutor.shutdownNow();
+            duplicateWarningExecutor = null;
+        }
+    }
+
+    private @Nullable String hostname() {
+        try {
+            return InetAddress.getLocalHost().getHostName();
+        } catch (UnknownHostException e) {
+            return null;
+        }
+    }
+
+    private @Nullable MigrationContext buildMigrationContext(@NotNull BackendV2 backend) {
+        if (backend instanceof MongoBackendV2 mongo) {
+            MongoDatabase db = mongo.unwrap(MongoDatabase.class).orElse(null);
+            if (db == null) return null;
+            maybeWarnUnexpectedIdShape(db);
+            return new MongoMigrationContext(db, logger);
+        }
+        if (backend instanceof PostgresBackendV2
+                || backend instanceof MysqlBackendV2
+                || backend instanceof SqliteBackendV2
+                || backend instanceof RedisBackendV2) {
+            return NO_OP_MIGRATION_CONTEXT;
+        }
+        return null;
+    }
+
+    private static final MigrationContext NO_OP_MIGRATION_CONTEXT =
+            new MigrationContext() {};
+
+    private void maybeWarnUnexpectedIdShape(@NotNull MongoDatabase db) {
+        for (String coll : new String[]{"grim_sessions", "grim_players"}) {
+            try {
+                Document first = db.getCollection(coll).find().limit(1).first();
+                if (first == null) continue;
+                Object id = first.get("_id");
+                if (id instanceof java.util.UUID) continue;
+                if (id instanceof Binary b
+                        && (b.getType() == BsonBinarySubType.BINARY.getValue()
+                        || b.getType() == BsonBinarySubType.UUID_STANDARD.getValue())
+                        && b.getData().length == 16) continue;
+                String idClass = id == null ? "null" : id.getClass().getSimpleName();
+                logger.warning(() -> "[grim-datastore] " + coll + " first-doc _id is "
+                        + idClass + ", expected UUID-shaped binary -"
+                        + " entity migration will not handle this row correctly."
+                        + " Halt and inspect before proceeding if this is unexpected.");
+            } catch (RuntimeException e) {
+                logger.fine(() -> "[grim-datastore] _id sanity probe failed for " + coll
+                        + ": " + e.getMessage());
+            }
+        }
+    }
+
+    private void closeV2Backends() {
+        for (BackendV2 v2 : v2Backends) {
+            try { v2.flush(); }
+            catch (Exception e) {
+                logger.log(Level.WARNING, "[grim-datastore] v2 flush failed for " + v2.id(), e);
+            }
+            try { v2.close(); }
+            catch (Exception e) {
+                logger.log(Level.WARNING, "[grim-datastore] v2 close failed for " + v2.id(), e);
+            }
+        }
+        v2Backends.clear();
+    }
+
+    private NameResolver buildNameResolver(
+            DataStore store,
+            List<String> chain,
+            boolean playerIdentityRouted) {
         List<NameResolverLink> links = new ArrayList<>();
         for (String id : chain) {
             switch (id) {
-                case "local-cache" -> links.add(new LocalCacheLink(store));
+                case "local-cache" -> {
+                    if (playerIdentityRouted) {
+                        links.add(new LocalCacheLink(store));
+                    } else {
+                        logger.warning("[grim-datastore] local-cache name resolver disabled; "
+                                + "missing player-identity route");
+                    }
+                }
                 case "offline-mode-uuid" -> links.add(new OfflineModeUuidLink());
                 default -> logger.warning("[grim-datastore] unknown name-resolver link: " + id);
             }
@@ -205,9 +969,6 @@ public final class DataStoreLifecycle implements StartableInitable, StoppableIni
     }
 
     private void maybeMigrateLegacy(Path dataFolder, SqliteBackend sqliteBackend) {
-        // The V0 reader/import path is SQLite-only. Only run it when the
-        // violation route itself is SQLite; mixed routing should not import
-        // legacy violations into an unrelated local side database.
         if (sqliteBackend == null) return;
         if (config.migration().skip()) {
             logger.info("[grim-datastore] migration.skip=true; leaving legacy v0 un-migrated");
@@ -216,7 +977,6 @@ public final class DataStoreLifecycle implements StartableInitable, StoppableIni
         V0Sources.V0Source source = V0Sources.detect(
                 dataFolder,
                 GrimAPI.INSTANCE.getConfigManager().getConfig());
-        // No legacy store on disk — fresh install or migration already done.
         if (source == null) {
             logger.info("[grim-datastore] no legacy v0 store detected; nothing to migrate");
             return;
@@ -241,137 +1001,128 @@ public final class DataStoreLifecycle implements StartableInitable, StoppableIni
         }
     }
 
-    // Source detection moved to V0Sources so the /grim history migrate command
-    // can reuse the same routing logic. See that class for per-type builders.
-
     @Override
     public void stop() {
-        teardown();
+        close();
     }
 
-    /**
-     * Hot-reload from a freshly-refreshed ConfigManager. Drains in-flight
-     * writes within the configured {@code shutdown-drain-timeout-ms},
-     * drops anything still pending, then rebuilds backends + routing
-     * from the new {@code database.yml} / {@code databases/&lt;id&gt;.yml}.
-     *
-     * <p>Operators can swap the backend (e.g. SQLite → MySQL after a
-     * {@code /grim history migrate}) without bouncing the server. Brief
-     * unavailability between the drain and the new backend's init —
-     * writes during that window get dropped on the floor; the user
-     * accepts that tradeoff.
-     *
-     * <p>Stale references held by callers (e.g. a check that cached
-     * {@link LiveWriteHooks} in a local variable mid-event) keep working
-     * against the old, closed dataStore — those writes drop too. New
-     * lookups via {@link #liveWriteHooks()} resolve to the new instance.
-     */
     public synchronized void reload() {
         logger.info("[grim-datastore] /grim reload: tearing down datastore...");
-        teardown();
+        close();
         start();
     }
 
-    /**
-     * Idempotent teardown — drains writers, closes backends, nulls every
-     * service field. Used by both {@link #stop()} and {@link #reload()}.
-     * Doesn't touch {@code enabled}; {@link #start()} re-evaluates that
-     * from the freshly-loaded ConfigManager.
-     */
-    private void teardown() {
-        // violationSink drains in-flight writes; dataStore drains per-category
-        // rings and closes each backend. Both null-guarded because a failure
-        // during buildAndStart can tear down mid-initialisation — start()'s
-        // catch calls teardown() before any of these fields were assigned.
-        if (playerToggleStore != null) playerToggleStore.shutdown();
+    private synchronized void close() {
+        stopDuplicateWarning();
+        stopRecoverySweep();
+        if (!enabled) return;
+        stopHeartbeatSchedulersForShutdown();
+        playerToggleStore.shutdown();
         if (violationSink != null) violationSink.shutDown();
-        if (dataStore != null) {
-            long drainMs = config != null ? config.writePath().shutdownDrainTimeoutMs() : 5000L;
-            dataStore.flushAndClose(drainMs);
-        }
+        shutdownInstanceRegistry();
+        if (dataStore != null && config != null) dataStore.flushAndClose(config.writePath().shutdownDrainTimeoutMs());
+        closeOwnership("graceful");
+        ownershipGate.close("shutdown");
+        closeV2Backends();
         dataStore = null;
         historyService = null;
         playerIdentityService = null;
         nameResolver = null;
         violationSink = null;
         retentionSweeper = null;
-        sessionTracker = null;
-        liveWriteHooks = null;
-        playerToggleStore = null;
+        sessionTracker = SessionTracker.NOOP;
+        liveWriteHooks = LiveWriteHooks.NOOP;
+        playerToggleStore = PlayerToggleStore.NOOP;
+        instanceRegistry = null;
+        ownershipAdapter = null;
+        ownershipFence = null;
+        ownershipGate = ServerOwnershipGate.disabled();
+        instanceId = null;
+        startupId = null;
+        startupStartedEpochMs = 0L;
         checkRegistry = null;
         config = null;
         loaded = false;
     }
 
+    private void stopHeartbeatSchedulersForShutdown() {
+        if (ownershipHeartbeatScheduler != null) {
+            ownershipHeartbeatScheduler.publishNowAndWait();
+            ownershipHeartbeatScheduler.stop();
+            ownershipHeartbeatScheduler = null;
+        }
+        if (heartbeatScheduler != null) {
+            heartbeatScheduler.publishNowAndWait();
+            heartbeatScheduler.stop();
+            heartbeatScheduler = null;
+        }
+    }
+
+    private void shutdownInstanceRegistry() {
+        if (instanceRegistry == null || startupId == null || config == null) return;
+        if (ownershipGate.enforced() && !ownershipGate.allowWrites()) {
+            logger.warning("[grim-datastore] skipping startup/session shutdown writes because DB ownership is no longer held");
+            return;
+        }
+        long now = dbNowBestEffort();
+        try {
+            long closed = instanceRegistry.closeCurrentStartup(startupId, now);
+            if (closed > 0) {
+                logger.info("[grim-datastore] closed " + closed
+                        + " still-open session(s) for this server startup");
+            }
+        } catch (RuntimeException e) {
+            logger.log(Level.WARNING,
+                    "[grim-datastore] failed to close sessions for this server startup", e);
+        }
+    }
+
+    private void closeOwnership(@NotNull String reason) {
+        if (ownershipAdapter == null || instanceId == null || startupId == null || ownershipFence == null) return;
+        try {
+            ownershipAdapter.closeOwnership(OWNERSHIP_STORE, instanceId, startupId, ownershipFence, reason);
+        } catch (Exception e) {
+            logger.log(Level.WARNING, "[grim-datastore] failed to close server ownership row", e);
+        }
+    }
+
+    private synchronized void disablePersistenceAfterLostOwnership() {
+        stopRecoverySweep();
+        sessionTracker = SessionTracker.NOOP;
+        liveWriteHooks = LiveWriteHooks.NOOP;
+        playerToggleStore = PlayerToggleStore.NOOP;
+        if (violationSink != null) {
+            violationSink.shutDown();
+            violationSink = null;
+        }
+    }
+
     public boolean isEnabled() { return enabled; }
     public boolean isLoaded() { return loaded; }
 
-    public @Nullable DataStore dataStore() { return dataStore; }
+    public @Nullable DataStore dataStore() { return loaded ? dataStore : null; }
     public @Nullable HistoryService historyService() { return historyService; }
     public @Nullable NameResolver nameResolver() { return nameResolver; }
     public @Nullable ViolationSink violationSink() { return violationSink; }
     public @Nullable DataStoreConfig config() { return config; }
 
-    /**
-     * The live-writes facade used by {@code PunishmentManager} and
-     * {@code PacketPlayerJoinQuit}. Returns {@link LiveWriteHooks#NOOP} when
-     * the datastore is disabled or its init failed — callers don't null-check.
-     */
-    public @NotNull LiveWriteHooks liveWriteHooks() { return loaded ? liveWriteHooks : LiveWriteHooks.NOOP; }
+    public @NotNull LiveWriteHooks liveWriteHooks() { return liveWriteHooks; }
+    public @NotNull SessionTracker sessionTracker() { return sessionTracker; }
+    public @NotNull PlayerToggleStore playerToggleStore() { return playerToggleStore; }
 
-    /**
-     * The live session tracker. Returns {@link SessionTracker#NOOP} when the
-     * datastore is disabled or its init failed.
-     */
-    public @NotNull SessionTracker sessionTracker() { return loaded ? sessionTracker : SessionTracker.NOOP; }
-
-    /**
-     * Persistence layer for the per-player /grim alerts | verbose | brands
-     * toggles. Returns {@link PlayerToggleStore#NOOP} when the datastore is
-     * disabled or its init failed.
-     */
-    public @NotNull PlayerToggleStore playerToggleStore() { return loaded ? playerToggleStore : PlayerToggleStore.NOOP; }
-
-    /**
-     * Admin-command escape hatch used by {@code /grim history migrate} to target
-     * SQLite directly. Scans the active router for a {@link SqliteBackend}
-     * instance; returns null when routing doesn't include one (e.g. pure-memory
-     * test setups, or a site that routes everything to a non-SQL backend). The
-     * migration command degrades gracefully in that case.
-     */
     @ApiStatus.Internal
     public @Nullable SqliteBackend sqliteBackendForCommands() {
-        if (dataStore == null) return null;
-        for (Backend b : dataStore.router().allBackends()) {
-            if (b instanceof SqliteBackend s) return s;
-        }
         return null;
     }
 
-    /**
-     * Admin-command escape hatch. Returns the shared {@code CheckRegistry}
-     * instance so {@code /grim history migrate} can intern stable keys through
-     * the same registry the migrator uses at startup.
-     */
     @ApiStatus.Internal
     public @Nullable CheckRegistry checkRegistryForCommands() {
         return checkRegistry;
     }
 
-    /**
-     * Admin-command escape hatch. Returns all backends currently wired into the
-     * router, keyed by backend id. {@code /grim history copy} uses this to
-     * resolve {@code <src>} / {@code <dst>} arguments against the same backend
-     * instances the write path uses.
-     */
     @ApiStatus.Internal
     public @NotNull Map<String, Backend> allBackendsForCommands() {
-        if (dataStore == null) return Map.of();
-        Map<String, Backend> out = new LinkedHashMap<>();
-        for (Backend b : dataStore.router().allBackends()) {
-            out.put(b.id(), b);
-        }
-        return out;
+        return Map.of();
     }
 
     private record SimpleContext(BackendConfig config, Logger logger, Path dataDirectory) implements BackendContext {}

--- a/common/src/main/java/ac/grim/grimac/manager/datastore/IdentityLiveWriteHooks.java
+++ b/common/src/main/java/ac/grim/grimac/manager/datastore/IdentityLiveWriteHooks.java
@@ -1,0 +1,54 @@
+package ac.grim.grimac.manager.datastore;
+
+import ac.grim.grimac.api.AbstractCheck;
+import ac.grim.grimac.internal.storage.identity.PlayerIdentityService;
+import ac.grim.grimac.platform.api.player.PlatformPlayer;
+import ac.grim.grimac.player.GrimPlayer;
+import com.github.retrooper.packetevents.protocol.player.User;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.UUID;
+
+final class IdentityLiveWriteHooks implements LiveWriteHooks {
+
+    private final PlayerIdentityService identityService;
+
+    IdentityLiveWriteHooks(@NotNull PlayerIdentityService identityService) {
+        this.identityService = identityService;
+    }
+
+    @Override
+    public void onJoin(
+            @NotNull UUID uuid,
+            @Nullable String name,
+            long now,
+            @NotNull SessionTracker.ClientMeta meta) {
+        identityService.observe(uuid, name, now);
+    }
+
+    @Override public void onQuit(@NotNull UUID uuid, long now, @NotNull SessionTracker.ClientMeta meta) {}
+    @Override public void observeBrand(@NotNull UUID uuid, long now, @NotNull SessionTracker.ClientMeta meta) {}
+
+    @Override
+    public void recordFlag(
+            @NotNull UUID playerUuid,
+            @NotNull AbstractCheck check,
+            double vl,
+            @Nullable String verbose,
+            long now,
+            @NotNull SessionTracker.ClientMeta meta) {
+    }
+
+    @Override public void onJoinFromUserLogin(@NotNull PlatformPlayer player, @NotNull User user, long now) {}
+    @Override public void onQuitFromUserDisconnect(@NotNull User user, @Nullable GrimPlayer grimPlayer, long now) {}
+    @Override public void observeBrandFromCheck(@NotNull GrimPlayer grimPlayer) {}
+
+    @Override
+    public void recordFlagFromCheck(
+            @NotNull GrimPlayer player,
+            @NotNull AbstractCheck check,
+            double vl,
+            @Nullable String verbose) {
+    }
+}

--- a/common/src/main/java/ac/grim/grimac/manager/datastore/OwnershipHeartbeatScheduler.java
+++ b/common/src/main/java/ac/grim/grimac/manager/datastore/OwnershipHeartbeatScheduler.java
@@ -1,0 +1,178 @@
+package ac.grim.grimac.manager.datastore;
+
+import ac.grim.grimac.api.storage.event.ServerStartupEvent;
+import ac.grim.grimac.api.storage.instance.OwnershipRenewResult;
+import ac.grim.grimac.api.storage.instance.ServerOwnershipAdapter;
+import ac.grim.grimac.api.storage.instance.ServerOwnershipGate;
+import ac.grim.grimac.api.storage.registry.StoreId;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.time.Duration;
+import java.util.UUID;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+final class OwnershipHeartbeatScheduler {
+
+    private final @NotNull ServerOwnershipAdapter ownership;
+    private final @NotNull StoreId ownershipStore;
+    private final @NotNull UUID startupId;
+    private final @NotNull UUID instanceId;
+    private final @NotNull UUID fence;
+    private final @NotNull String serverName;
+    private final long startedEpochMs;
+    private final @Nullable String hostname;
+    private final @Nullable String grimVersion;
+    private final @Nullable String serverVersionString;
+    private final @NotNull Supplier<byte @Nullable []> verboseManifest;
+    private final long leaseTtlMs;
+    private final long safetyMarginMs;
+    private final @NotNull Duration interval;
+    private final @NotNull ServerOwnershipGate gate;
+    private final @NotNull Consumer<ServerStartupEvent> publish;
+    private final @NotNull Runnable lostOwnership;
+    private final @NotNull Logger logger;
+    private final AtomicBoolean lost = new AtomicBoolean(false);
+
+    private final Object lifecycleLock = new Object();
+    private @Nullable ScheduledExecutorService executor;
+    private @Nullable ScheduledFuture<?> task;
+    private volatile @Nullable Thread schedulerThread;
+
+    OwnershipHeartbeatScheduler(
+            @NotNull ServerOwnershipAdapter ownership,
+            @NotNull StoreId ownershipStore,
+            @NotNull UUID startupId,
+            @NotNull UUID instanceId,
+            @NotNull UUID fence,
+            @NotNull String serverName,
+            long startedEpochMs,
+            @Nullable String hostname,
+            @Nullable String grimVersion,
+            @Nullable String serverVersionString,
+            @NotNull Supplier<byte @Nullable []> verboseManifest,
+            long leaseTtlMs,
+            long safetyMarginMs,
+            @NotNull Duration interval,
+            @NotNull ServerOwnershipGate gate,
+            @NotNull Consumer<ServerStartupEvent> publish,
+            @NotNull Runnable lostOwnership,
+            @NotNull Logger logger) {
+        this.ownership = ownership;
+        this.ownershipStore = ownershipStore;
+        this.startupId = startupId;
+        this.instanceId = instanceId;
+        this.fence = fence;
+        this.serverName = serverName;
+        this.startedEpochMs = startedEpochMs;
+        this.hostname = hostname;
+        this.grimVersion = grimVersion;
+        this.serverVersionString = serverVersionString;
+        this.verboseManifest = verboseManifest;
+        this.leaseTtlMs = leaseTtlMs;
+        this.safetyMarginMs = safetyMarginMs;
+        this.interval = interval;
+        this.gate = gate;
+        this.publish = publish;
+        this.lostOwnership = lostOwnership;
+        this.logger = logger;
+    }
+
+    void start() {
+        synchronized (lifecycleLock) {
+            if (executor != null) return;
+            executor = Executors.newSingleThreadScheduledExecutor(r -> {
+                Thread t = new Thread(r, "grim-storage-ownership-" + serverName);
+                t.setDaemon(true);
+                schedulerThread = t;
+                return t;
+            });
+            long periodMs = Math.max(1L, interval.toMillis());
+            task = executor.scheduleAtFixedRate(this::tick, 0L, periodMs, TimeUnit.MILLISECONDS);
+        }
+    }
+
+    void publishNowAndWait() {
+        ScheduledExecutorService current;
+        synchronized (lifecycleLock) {
+            current = executor;
+        }
+        if (current == null || lost.get()) return;
+        if (Thread.currentThread() == schedulerThread) {
+            tick();
+            return;
+        }
+        Future<?> future = current.submit(this::tick);
+        try {
+            future.get();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        } catch (ExecutionException e) {
+            logger.log(Level.WARNING, "ownership heartbeat failed for startup " + startupId, e.getCause());
+        }
+    }
+
+    void stop() {
+        synchronized (lifecycleLock) {
+            if (task != null) {
+                task.cancel(false);
+                task = null;
+            }
+            if (executor != null) {
+                executor.shutdownNow();
+                executor = null;
+                schedulerThread = null;
+            }
+        }
+    }
+
+    private void tick() {
+        if (lost.get()) return;
+        try {
+            OwnershipRenewResult renewed = ownership.renewOwnership(
+                    ownershipStore, instanceId, startupId, fence, leaseTtlMs);
+            if (!renewed.renewed()) {
+                onLostOwnership();
+                return;
+            }
+            gate.extend(startupId, fence, leaseTtlMs, safetyMarginMs);
+            ServerStartupEvent event = new ServerStartupEvent()
+                    .startupId(startupId)
+                    .instanceId(instanceId)
+                    .serverName(serverName)
+                    .startedEpochMs(startedEpochMs)
+                    .lastHeartbeatEpochMs(renewed.dbNowEpochMs())
+                    .hostname(hostname)
+                    .grimVersion(grimVersion)
+                    .serverVersionString(serverVersionString)
+                    .verboseManifest(verboseManifest.get());
+            publish.accept(event);
+        } catch (RuntimeException e) {
+            logger.log(Level.WARNING, "ownership heartbeat failed for startup " + startupId, e);
+        } catch (Exception e) {
+            logger.log(Level.WARNING, "ownership heartbeat failed for startup " + startupId, e);
+        }
+    }
+
+    private void onLostOwnership() {
+        if (!lost.compareAndSet(false, true)) return;
+        gate.close("lost-ownership");
+        logger.warning("[grim-datastore] lost DB ownership for instanceId=" + instanceId
+                + " startupId=" + startupId + "; disabling persistence for this boot");
+        try {
+            lostOwnership.run();
+        } finally {
+            stop();
+        }
+    }
+}

--- a/common/src/main/java/ac/grim/grimac/manager/datastore/SessionTrackerImpl.java
+++ b/common/src/main/java/ac/grim/grimac/manager/datastore/SessionTrackerImpl.java
@@ -2,6 +2,7 @@ package ac.grim.grimac.manager.datastore;
 
 import ac.grim.grimac.api.storage.DataStore;
 import ac.grim.grimac.api.storage.category.Categories;
+import ac.grim.grimac.api.storage.model.SessionRecord;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -16,14 +17,22 @@ import java.util.concurrent.ConcurrentHashMap;
 public final class SessionTrackerImpl implements SessionTracker {
 
     private final DataStore store;
-    private final String serverName;
     private final long heartbeatIntervalMs;
+    private final @Nullable UUID startupId;
     private final Map<UUID, State> states = new ConcurrentHashMap<>();
 
     public SessionTrackerImpl(@NotNull DataStore store, @NotNull String serverName, long heartbeatIntervalMs) {
+        this(store, serverName, heartbeatIntervalMs, null);
+    }
+
+    public SessionTrackerImpl(
+            @NotNull DataStore store,
+            @NotNull String serverName,
+            long heartbeatIntervalMs,
+            @Nullable UUID startupId) {
         this.store = store;
-        this.serverName = serverName;
         this.heartbeatIntervalMs = heartbeatIntervalMs;
+        this.startupId = startupId;
     }
 
     @Override
@@ -39,13 +48,14 @@ public final class SessionTrackerImpl implements SessionTracker {
                 if (candidateSessionId == null) candidateSessionId = UUID.randomUUID();
                 State fresh = new State(candidateSessionId, now, now, now, meta);
                 if (states.putIfAbsent(playerUuid, fresh) == null) {
-                    emit(fresh, playerUuid, now, null); // closed_at stays null while alive
+                    emit(fresh, playerUuid, now, null); // closed_at stays OPEN while alive
                     return fresh.sessionId;
                 }
                 // Lost the insert race — someone inserted between get and putIfAbsent. Retry as update.
                 continue;
             }
-            State next = new State(current.sessionId, current.startedEpochMs, now, now, meta);
+            State next = new State(current.sessionId, current.startedEpochMs, now, now,
+                    mergeMeta(current.cachedMeta, meta));
             if (states.replace(playerUuid, current, next)) {
                 emit(next, playerUuid, now, null);
                 return next.sessionId;
@@ -72,7 +82,12 @@ public final class SessionTrackerImpl implements SessionTracker {
     public void close(@NotNull UUID playerUuid, long now, @NotNull ClientMeta meta) {
         State prev = states.remove(playerUuid);
         if (prev == null) return;
-        emit(new State(prev.sessionId, prev.startedEpochMs, now, now, meta), playerUuid, now, now);
+        // Emit last_activity from the prev state (the last actual observation),
+        // closed_at = now (the disconnect timestamp). They diverge by design so
+        // crash recovery can stamp closed_at = last_activity for orphaned rows.
+        State closed = new State(prev.sessionId, prev.startedEpochMs, prev.lastActivityEpochMs, now,
+                mergeMeta(prev.cachedMeta, meta));
+        emit(closed, playerUuid, prev.lastActivityEpochMs, now);
     }
 
     @Override
@@ -88,14 +103,24 @@ public final class SessionTrackerImpl implements SessionTracker {
         store.submit(Categories.SESSION, e -> e
                 .sessionId(sessionId)
                 .playerUuid(playerUuid)
-                .serverName(serverName)
                 .startedEpochMs(started)
                 .lastActivityEpochMs(now)
-                .closedAtEpochMs(closedAt)
-                .grimVersion(meta.grimVersion())
+                .closedAtEpochMs(closedAt == null ? SessionRecord.OPEN : closedAt)
                 .clientBrand(meta.clientBrand())
                 .clientVersion(meta.clientVersion())
-                .serverVersionString(meta.serverVersion()));
+                .startupId(startupId));
+    }
+
+    private static ClientMeta mergeMeta(ClientMeta current, ClientMeta incoming) {
+        return new ClientMeta(
+                latest(incoming.grimVersion(), current.grimVersion()),
+                current.clientBrand() != null ? current.clientBrand() : incoming.clientBrand(),
+                incoming.clientVersion() >= 0 ? incoming.clientVersion() : current.clientVersion(),
+                latest(incoming.serverVersion(), current.serverVersion()));
+    }
+
+    private static <T> T latest(T incoming, T current) {
+        return incoming != null ? incoming : current;
     }
 
     private record State(UUID sessionId,

--- a/common/src/main/java/ac/grim/grimac/manager/datastore/V2InstanceRegistry.java
+++ b/common/src/main/java/ac/grim/grimac/manager/datastore/V2InstanceRegistry.java
@@ -1,0 +1,356 @@
+package ac.grim.grimac.manager.datastore;
+
+import ac.grim.grimac.api.storage.DataStore;
+import ac.grim.grimac.api.storage.backend.ApiVersion;
+import ac.grim.grimac.api.storage.backend.Backend;
+import ac.grim.grimac.api.storage.backend.BackendContext;
+import ac.grim.grimac.api.storage.backend.BackendException;
+import ac.grim.grimac.api.storage.backend.KindAdapter;
+import ac.grim.grimac.api.storage.backend.StorageEventHandler;
+import ac.grim.grimac.api.storage.category.Capability;
+import ac.grim.grimac.api.storage.category.Categories;
+import ac.grim.grimac.api.storage.category.Category;
+import ac.grim.grimac.api.storage.check.CheckCatalogPersistence;
+import ac.grim.grimac.api.storage.check.CheckCatalogRepairResult;
+import ac.grim.grimac.api.storage.event.ServerStartupEvent;
+import ac.grim.grimac.api.storage.event.SessionEvent;
+import ac.grim.grimac.api.storage.kind.ops.EntityOps;
+import ac.grim.grimac.api.storage.model.ServerStartupRecord;
+import ac.grim.grimac.api.storage.model.SessionRecord;
+import ac.grim.grimac.api.storage.query.Cursor;
+import ac.grim.grimac.api.storage.query.DeleteCriteria;
+import ac.grim.grimac.api.storage.query.Page;
+import ac.grim.grimac.api.storage.query.Query;
+import ac.grim.grimac.internal.storage.checks.InMemoryCheckCatalogPersistence;
+import ac.grim.grimac.internal.storage.core.V2Routes;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.EnumSet;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.ExecutionException;
+import java.util.logging.Logger;
+
+final class V2InstanceRegistry {
+
+    static final Category<ServerStartupEvent> STARTUPS = Categories.SERVER_STARTUP;
+    static final Backend ROUTER_SENTINEL_BACKEND = new RouterSentinelBackend();
+
+    private static final int PAGE_SIZE = 512;
+
+    private final DataStore store;
+    private final StorageEventHandler<ServerStartupEvent> directStartupWriter;
+    private final StorageEventHandler<SessionEvent> directSessionWriter;
+    private final Logger logger;
+
+    private V2InstanceRegistry(
+            @NotNull DataStore store,
+            @NotNull V2Routes.Route<?> startupsRoute,
+            @NotNull V2Routes.Route<?> sessionsRoute,
+            @NotNull Logger logger) {
+        this.store = store;
+        this.directStartupWriter = directWriter(startupsRoute, STARTUPS);
+        this.directSessionWriter = directWriter(sessionsRoute, Categories.SESSION);
+        this.logger = logger;
+    }
+
+    static @Nullable V2InstanceRegistry create(
+            @NotNull DataStore store,
+            @NotNull V2Routes routes,
+            @NotNull Logger logger) {
+        V2Routes.Route<?> startups = routes.routeFor(STARTUPS);
+        V2Routes.Route<?> sessions = routes.routeFor(Categories.SESSION);
+        if (startups == null || sessions == null) return null;
+        return new V2InstanceRegistry(store, startups, sessions, logger);
+    }
+
+    void publish(@NotNull ServerStartupEvent source) {
+        writeStartup(source);
+    }
+
+    StartupClaim openStartup(
+            @NotNull String serverName,
+            @NotNull UUID instanceId,
+            @NotNull UUID startupId,
+            @NotNull UUID fence,
+            long startedEpochMs,
+            long dbNowEpochMs,
+            @Nullable String hostname,
+            @Nullable String grimVersion,
+            @Nullable String serverVersionString,
+            @Nullable byte[] verboseManifest) {
+        ServerStartupRecord current = new ServerStartupRecord(
+                startupId,
+                instanceId,
+                serverName,
+                grimVersion,
+                serverVersionString,
+                hostname,
+                startedEpochMs,
+                dbNowEpochMs,
+                ServerStartupRecord.OPEN,
+                null,
+                verboseManifest);
+        writeStartup(current);
+        String message = "[grim-datastore] storage startup claimed: serverName='" + serverName
+                + "' instanceId=" + instanceId
+                + " startupId=" + startupId
+                + " fence=" + fence + ".";
+        logger.info(message);
+        return StartupClaim.enabled(startupId, instanceId, 0L, message);
+    }
+
+    long closeCurrentStartup(@NotNull UUID startupId, long closedAtEpochMs) {
+        Optional<ServerStartupRecord> row = startupById(startupId);
+        long closed = closeOpenSessions(startupId, closedAtEpochMs);
+        row.ifPresent(startup -> markStartupClosed(startup, closedAtEpochMs, "graceful"));
+        return closed;
+    }
+
+    long recoverStaleStartups(
+            @NotNull UUID currentStartupId,
+            long now,
+            long staleThresholdMs) {
+        long closed = 0L;
+        Cursor cursor = null;
+        boolean stop = false;
+        do {
+            Page<ServerStartupRecord> page = await(store.execute(new EntityOps.FindByIndexOp<>(
+                    STARTUPS,
+                    "by_open_heartbeat",
+                    ServerStartupRecord.OPEN,
+                    cursor,
+                    PAGE_SIZE)), "query stale server startups");
+            for (ServerStartupRecord row : page.items()) {
+                if (row.isClosed()) continue;
+                if (!isStale(row, now, staleThresholdMs)) {
+                    stop = true;
+                    break;
+                }
+                if (currentStartupId.equals(row.startupId())) continue;
+                closed += recoverStartup(row, "stale");
+            }
+            cursor = stop ? null : page.nextCursor();
+        } while (cursor != null);
+        return closed;
+    }
+
+    long recoverStartup(@NotNull UUID startupId, @NotNull String reason) {
+        Optional<ServerStartupRecord> startup = startupById(startupId);
+        return startup.map(row -> recoverStartup(row, reason)).orElse(0L);
+    }
+
+    private long recoverStartup(@NotNull ServerStartupRecord startup, @NotNull String reason) {
+        long closed = closeOpenSessions(startup.startupId(), SessionRecord.OPEN);
+        long closeAt = Math.max(startup.startedEpochMs(), startup.lastHeartbeatEpochMs());
+        markStartupClosed(startup, closeAt, reason);
+        if (closed > 0) {
+            logger.warning("[grim-datastore] recovered startupId=" + startup.startupId()
+                    + " serverName='" + startup.serverName() + "' reason=" + reason
+                    + " and closed " + closed + " open session(s).");
+        }
+        return closed;
+    }
+
+    private long closeOpenSessions(@NotNull UUID startupId, long closedAtEpochMs) {
+        long closed = 0L;
+        Cursor cursor = null;
+        boolean reachedClosedRows;
+        do {
+            reachedClosedRows = false;
+            Page<SessionRecord> page = await(store.execute(new EntityOps.FindByIndexOp<>(
+                    Categories.SESSION,
+                    "by_startup_open",
+                    startupId,
+                    cursor,
+                    PAGE_SIZE)), "query open sessions for startup " + startupId);
+            for (SessionRecord session : page.items()) {
+                if (!startupId.equals(session.startupId())) continue;
+                if (session.isClosed()) {
+                    reachedClosedRows = true;
+                    continue;
+                }
+                long closeAt = closedAtEpochMs == SessionRecord.OPEN
+                        ? session.lastActivityEpochMs()
+                        : closedAtEpochMs;
+                closeSession(session, closeAt);
+                closed++;
+            }
+            cursor = reachedClosedRows ? null : page.nextCursor();
+        } while (cursor != null);
+        return closed;
+    }
+
+    private void closeSession(@NotNull SessionRecord source, long closedAtEpochMs) {
+        SessionEvent event = new SessionEvent()
+                .sessionId(source.sessionId())
+                .playerUuid(source.playerUuid())
+                .startedEpochMs(source.startedEpochMs())
+                .lastActivityEpochMs(source.lastActivityEpochMs())
+                .closedAtEpochMs(closedAtEpochMs)
+                .clientBrand(source.clientBrand())
+                .clientVersion(source.clientVersion())
+                .startupId(source.startupId());
+        try {
+            directSessionWriter.onEvent(event, 0L, true);
+        } catch (Exception e) {
+            throw new RuntimeException("failed to close session " + source.sessionId(), e);
+        }
+    }
+
+    private void markStartupClosed(
+            @NotNull ServerStartupRecord source,
+            long closedAtEpochMs,
+            @NotNull String reason) {
+        long closeAt = closedAtEpochMs == ServerStartupRecord.OPEN
+                ? Math.max(source.startedEpochMs(), source.lastHeartbeatEpochMs())
+                : closedAtEpochMs;
+        ServerStartupRecord closed = new ServerStartupRecord(
+                source.startupId(),
+                source.instanceId(),
+                source.serverName(),
+                source.grimVersion(),
+                source.serverVersionString(),
+                source.hostname(),
+                source.startedEpochMs(),
+                Math.max(source.lastHeartbeatEpochMs(), closeAt),
+                closeAt,
+                reason,
+                source.verboseManifest());
+        writeStartup(closed);
+    }
+
+    private void writeStartup(@NotNull ServerStartupRecord source) {
+        ServerStartupEvent event = new ServerStartupEvent()
+                .startupId(source.startupId())
+                .instanceId(source.instanceId())
+                .serverName(source.serverName())
+                .startedEpochMs(source.startedEpochMs())
+                .lastHeartbeatEpochMs(source.lastHeartbeatEpochMs())
+                .hostname(source.hostname())
+                .grimVersion(source.grimVersion())
+                .serverVersionString(source.serverVersionString())
+                .verboseManifest(source.verboseManifest())
+                .closedAtEpochMs(source.closedAtEpochMs())
+                .closeReason(source.closeReason());
+        writeStartup(event);
+    }
+
+    private void writeStartup(@NotNull ServerStartupEvent source) {
+        try {
+            directStartupWriter.onEvent(source, 0L, true);
+        } catch (Exception e) {
+            throw new RuntimeException("server startup write failed for " + source.startupId(), e);
+        }
+    }
+
+    private @NotNull Optional<ServerStartupRecord> startupById(@NotNull UUID startupId) {
+        return await(store.execute(new EntityOps.GetByIdOp<UUID, ServerStartupRecord>(
+                STARTUPS, startupId)), "query server startup " + startupId);
+    }
+
+    private static boolean isStale(@NotNull ServerStartupRecord row, long now, long staleThresholdMs) {
+        return heartbeatAgeMs(now, row) > staleThresholdMs;
+    }
+
+    private static long heartbeatAgeMs(long now, @NotNull ServerStartupRecord row) {
+        return Math.max(0L, now - row.lastHeartbeatEpochMs());
+    }
+
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    private static <E> @NotNull StorageEventHandler<E> directWriter(
+            @NotNull V2Routes.Route<?> route,
+            @NotNull Category<E> category) {
+        KindAdapter adapter = route.adapter();
+        return adapter.writeHandler(route.storeId(), route.kind(), category);
+    }
+
+    private static <T> T await(@NotNull java.util.concurrent.CompletionStage<T> stage,
+                               @NotNull String action) {
+        try {
+            return stage.toCompletableFuture().get();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException(action + " interrupted", e);
+        } catch (ExecutionException e) {
+            Throwable cause = e.getCause();
+            if (cause instanceof CompletionException ce && ce.getCause() != null) cause = ce.getCause();
+            throw new RuntimeException(action + " failed", cause);
+        }
+    }
+
+    record StartupClaim(
+            boolean storageEnabled,
+            boolean duplicate,
+            @NotNull UUID startupId,
+            @NotNull UUID instanceId,
+            @Nullable UUID conflictingStartupId,
+            long heartbeatAgeMs,
+            long sessionsClosed,
+            @NotNull String warningMessage) {
+
+        static @NotNull StartupClaim enabled(
+                @NotNull UUID startupId,
+                @NotNull UUID instanceId,
+                long sessionsClosed,
+                @NotNull String message) {
+            return new StartupClaim(true, false, startupId, instanceId, null,
+                    -1L, sessionsClosed, message);
+        }
+
+        static @NotNull StartupClaim duplicate(
+                @NotNull UUID startupId,
+                @NotNull UUID instanceId,
+                @NotNull UUID conflictingStartupId,
+                long heartbeatAgeMs,
+                @NotNull String message) {
+            return new StartupClaim(false, true, startupId, instanceId, conflictingStartupId,
+                    heartbeatAgeMs, 0L, message);
+        }
+    }
+
+    @SuppressWarnings("deprecation")
+    private static final class RouterSentinelBackend implements Backend {
+        private final CheckCatalogPersistence checkCatalog = new InMemoryCheckCatalogPersistence();
+
+        @Override public @NotNull String id() { return "__v2_startup_registry"; }
+        @Override public @NotNull ApiVersion getApiVersion() { return ApiVersion.CURRENT; }
+        @Override public @NotNull EnumSet<Capability> capabilities() { return EnumSet.noneOf(Capability.class); }
+        @Override public @NotNull Set<Category<?>> supportedCategories() { return new HashSet<>(); }
+        @Override public void init(@NotNull BackendContext ctx) {}
+        @Override public @NotNull CheckCatalogPersistence checkCatalog() { return checkCatalog; }
+
+        @Override
+        public @NotNull CheckCatalogRepairResult repairCheckCatalog(
+                @NotNull Map<Integer, Integer> legacyToCatalogCheckIds,
+                @Nullable String introducedVersionReplacement) {
+            return new CheckCatalogRepairResult(0, 0L, 0L);
+        }
+
+        @Override public void flush() {}
+        @Override public void close() {}
+
+        @Override
+        public @NotNull <E> StorageEventHandler<E> eventHandlerFor(@NotNull Category<E> cat) throws BackendException {
+            throw new BackendException("sentinel backend has no legacy event handlers");
+        }
+
+        @Override
+        public @NotNull <R> Page<R> read(@NotNull Category<?> cat, @NotNull Query<R> query) throws BackendException {
+            throw new BackendException("sentinel backend has no legacy read path");
+        }
+
+        @Override
+        public <E> void delete(@NotNull Category<E> cat, @NotNull DeleteCriteria criteria) throws BackendException {
+            throw new BackendException("sentinel backend has no legacy delete path");
+        }
+
+        @Override public long countViolationsInSession(@NotNull UUID sessionId) { return 0L; }
+    }
+}

--- a/common/src/main/resources/database/en.yml
+++ b/common/src/main/resources/database/en.yml
@@ -46,6 +46,24 @@ database:
     # 0 disables.
     heartbeat-interval-ms: 30000
 
+  ownership:
+    # Prevent two live servers with the same persistent storage UUID from
+    # writing to the same DB. Turn this off only if you intentionally accept
+    # duplicate writers.
+    enforce-persistent-uuid-ownership: true
+    # Options:
+    # - disable-storage: keep checks running but disable DB writes for this boot.
+    # - fail-startup: fail Grim storage startup on a live duplicate UUID.
+    # - allow-unsafe: expert-only; bypasses ownership enforcement.
+    duplicate-persistent-uuid-action: disable-storage
+    renew-interval-ms: 10000
+    lease-ttl-ms: 20000
+    startup-wait-ms: 20000
+    safety-margin-ms: 5000
+    stale-startup-ttl-ms: 30000
+    recovery-sweep-interval-ms: 10000
+    cleanup-other-servers: true
+
   write-path:
     # queue-capacity must be a positive power of two (ring-buffer requirement).
     # Typical values: 4096, 8192, 16384, 32768, 65536.

--- a/libs.versions.toml
+++ b/libs.versions.toml
@@ -11,7 +11,7 @@ cloud-processors-requirements = "1.0.0-rc.1"
 # --- Minecraft-Specific APIs ---
 floodgate-api = "2.0-SNAPSHOT"
 geyser-base-api = "1.0.2"
-grim-api = "1.5.0.3-10fed42"
+grim-api = "1.6.0.5-feat_server-ownership-leases-c31eab4"
 packetevents = "2.12.2+0759fbb-SNAPSHOT"
 placeholderapi = "2.11.6"
 viaversion = "5.9.0"
@@ -19,6 +19,7 @@ viaversion = "5.9.0"
 # --- General Java Utilities ---
 fastutil = "8.5.15"
 hikaricp = "7.0.2"
+mongoDriver = "5.3.1"
 jetbrains-annotations = "24.1.0"
 netty = "4.1.85.Final"
 snakeyaml = "2.2"
@@ -62,6 +63,7 @@ viabackwards = { group = "com.viaversion", name = "viabackwards", version.ref = 
 # --- General Java Utilities ---
 fastutil = { group = "it.unimi.dsi", name = "fastutil", version.ref = "fastutil"}
 hikaricp = { group = "com.zaxxer", name = "HikariCP", version.ref = "hikaricp" }
+mongo-driver-sync = { group = "org.mongodb", name = "mongodb-driver-sync", version.ref = "mongoDriver" }
 jetbrains-annotations = { group = "org.jetbrains", name = "annotations", version.ref = "jetbrains-annotations" }
 netty = { group = "io.netty", name = "netty-all", version.ref = "netty" }
 snakeyaml = { group = "org.yaml", name = "snakeyaml", version.ref = "snakeyaml" }

--- a/libs.versions.toml
+++ b/libs.versions.toml
@@ -11,7 +11,7 @@ cloud-processors-requirements = "1.0.0-rc.1"
 # --- Minecraft-Specific APIs ---
 floodgate-api = "2.0-SNAPSHOT"
 geyser-base-api = "1.0.2"
-grim-api = "1.6.0.5-feat_server-ownership-leases-c31eab4"
+grim-api = "1.6.0.6-50b54fe"
 packetevents = "2.12.2+0759fbb-SNAPSHOT"
 placeholderapi = "2.11.6"
 viaversion = "5.9.0"

--- a/libs.versions.toml
+++ b/libs.versions.toml
@@ -11,7 +11,7 @@ cloud-processors-requirements = "1.0.0-rc.1"
 # --- Minecraft-Specific APIs ---
 floodgate-api = "2.0-SNAPSHOT"
 geyser-base-api = "1.0.2"
-grim-api = "1.6.0.6-50b54fe"
+grim-api = "1.6.0.6"
 packetevents = "2.12.2+0759fbb-SNAPSHOT"
 placeholderapi = "2.11.6"
 viaversion = "5.9.0"

--- a/libs.versions.toml
+++ b/libs.versions.toml
@@ -11,7 +11,7 @@ cloud-processors-requirements = "1.0.0-rc.1"
 # --- Minecraft-Specific APIs ---
 floodgate-api = "2.0-SNAPSHOT"
 geyser-base-api = "1.0.2"
-grim-api = "1.6.0.6"
+grim-api = "1.6.0.7"
 packetevents = "2.12.2+0759fbb-SNAPSHOT"
 placeholderapi = "2.11.6"
 viaversion = "5.9.0"


### PR DESCRIPTION
## Summary
- Backports the v2 storage ownership lifecycle into Grim2.0.
- Uses persistent storage UUID ownership leases with startup rows, local write gate closure, duplicate UUID handling, crash takeover, stale cleanup, and lost-ownership persistence disablement.
- Keeps `disable-storage` as the default duplicate policy; `fail-startup` dispatches server `stop`.
- Keeps Redis/Jedis and other DB drivers on the holder-plugin path; Mongo is compileOnly for optional migration-context unwraps and is not shaded.

## Verification
- Published Review-GrimAPI ownership branch locally for the app build.
- `JAVA_HOME=/usr/lib/jvm/java-21-openjdk ./gradlew :common:compileJava`
- `JAVA_HOME=/usr/lib/jvm/java-21-openjdk ./gradlew :bukkit:compileJava`
- `JAVA_HOME=/usr/lib/jvm/java-21-openjdk ./gradlew :bukkit:shadowJar`
- `JAVA_HOME=/usr/lib/jvm/java-21-openjdk ./gradlew :common:test :bukkit:compileJava` (`:common:test` is NO_SOURCE)
- Jar inspection found no bundled/relocated Redis, CommonPool, Mongo, MySQL, Postgres, or SQLite driver packages.
- `javap` confirms Redis backend bytecode references unrelocated `redis/clients/jedis/*`.
- `Class.forName(DataStoreLifecycle, initialize=false)` succeeds from the built jar without DB driver jars on the classpath.
