### PR TITLE
Fix Vulcan compatibility: withhold pings until JOIN_GAME is sent

### DIFF
--- a/common/src/main/java/ac/grim/grimac/events/packets/PacketPlayerRespawn.java
+++ b/common/src/main/java/ac/grim/grimac/events/packets/PacketPlayerRespawn.java
@@ -114,6 +114,10 @@ public class PacketPlayerRespawn extends PacketListenerAbstract {
             GrimPlayer player = GrimAPI.INSTANCE.getPlayerDataManager().getPlayer(event.getUser());
             if (player == null) return;
 
+            // Only after this packet is actually written may we start sending pings/transactions.
+            // See sendTransaction() and Axionize/LightningGrim#127.
+            event.getTasksAfterSend().add(() -> player.hasSentJoinGamePacket.set(true));
+
             WrapperPlayServerJoinGame joinGame = new WrapperPlayServerJoinGame(event);
             player.gamemode = joinGame.getGameMode();
             player.entityID = joinGame.getEntityId();

--- a/common/src/main/java/ac/grim/grimac/player/GrimPlayer.java
+++ b/common/src/main/java/ac/grim/grimac/player/GrimPlayer.java
@@ -119,6 +119,10 @@ public class GrimPlayer implements GrimUser {
     private final AtomicInteger transactionIDCounter = new AtomicInteger(0);
     public final AtomicInteger lastTransactionSent = new AtomicInteger(0);
     public final AtomicInteger lastTransactionReceived = new AtomicInteger(0);
+    // Some anticheats (e.g. Vulcan) treat any ping/transaction received before their own
+    // JOIN_GAME handling as an out-of-order packet. Withhold our pings/transactions until
+    // JOIN_GAME has actually been written to the client. See: Axionize/LightningGrim#127
+    public final AtomicBoolean hasSentJoinGamePacket = new AtomicBoolean(false);
     // End transaction handling stuff
     // Manager like classes
     public final CheckManager checkManager;
@@ -493,6 +497,11 @@ public class GrimPlayer implements GrimUser {
         // don't send transactions outside PLAY phase
         // Sending in non-play corrupts the pipeline, don't waste bandwidth when anticheat disabled
         if (user.getEncoderState() != ConnectionState.PLAY) return;
+
+        // Withhold pings/transactions until JOIN_GAME has been sent, otherwise other
+        // anticheats (e.g. Vulcan) that assume JOIN_GAME is the first PLAY packet will
+        // see our ping arrive first and flag it as an out-of-order/invalid confirmation.
+        if (!hasSentJoinGamePacket.get()) return;
 
         // Send a packet once every 15 seconds to avoid any memory leaks
         if (disableGrim && (System.nanoTime() - getPlayerClockAtLeast()) > 15e9) {


### PR DESCRIPTION
## Summary

- Fixes Vulcan compatibility (#127). Grim could send a ping/transaction packet before `JOIN_GAME` was actually written to the client (e.g. from the `PLAYER_ABILITIES` send handler during the join sequence). Vulcan treats `JOIN_GAME` as the first PLAY packet it expects, so an early ping showed up as an out-of-order confirmation and got the player kicked.
- `GrimPlayer` now tracks whether `JOIN_GAME` has actually been sent (`hasSentJoinGamePacket`), set via `event.getTasksAfterSend()` in `PacketPlayerRespawn`'s existing `JOIN_GAME` handler, and `sendTransaction()` withholds until that flag is true.

## Important: `disable-pong-cancelling` must stay `false`

This PR does **not** replace the `disable-pong-cancelling` config option, and does not require enabling it. Server admins running Vulcan alongside Grim should leave `disable-pong-cancelling: false` (the default).

We confirmed this directly: a separate, ongoing mid-session kick (`out-of-order packet (Received X ≠ Expected Y)`, unrelated to join timing) was traced to `disable-pong-cancelling` being set to `true` on a test server — a workaround suggested elsewhere in #127 that turned out to make things worse. With it `true`, Grim stops cancelling its own transaction/pong responses, so Vulcan's own listener sees confirmation IDs it never sent and kicks for the mismatch. Setting it back to `false` (default `LOWEST`-priority cancellation in `PacketPingListener`) resolved that kick. Both fixes (this PR + correct config) were needed together to fully resolve Vulcan compatibility in our testing.

## Test plan

- [x] Compiles (`./gradlew build`)
- [x] Verified on a live server running Grim + Vulcan together (leafmc.one, 1.21.11) — join-time and mid-session out-of-order kicks both resolved with this change + `disable-pong-cancelling: false`
- [ ] Would appreciate a maintainer/Vulcan-side sanity check given the cross-plugin nature of this issue