### PR TITLE
item displays added to unhittable entities

### DIFF
--- a/common/src/main/java/ac/grim/grimac/utils/latency/CompensatedEntities.java
+++ b/common/src/main/java/ac/grim/grimac/utils/latency/CompensatedEntities.java
@@ -202,6 +202,7 @@ public class CompensatedEntities {
                 EntityTypes.isTypeInstanceOf(entityType, EntityTypes.ABSTRACT_ARROW)
                 || EntityTypes.FIREWORK_ROCKET.equals(entityType)
                 || EntityTypes.BLOCK_DISPLAY.equals(entityType)
+                || EntityTypes.ITEM_DISPLAY.equals(entityType)
                 || EntityTypes.TEXT_DISPLAY.equals(entityType)
                 || EntityTypes.LIGHTNING_BOLT.equals(entityType)
                 || EntityTypes.EXPERIENCE_BOTTLE.equals(entityType)


### PR DESCRIPTION
fixes false EntityPierce flags when attacking players through / around item display entities.
also noticed in testing that interaction entities false flag EntityPierce a lot too, they don't get handled properly by lightning & ignore both interactionWidth & interactionHeight
i didn't fix that here, but probably worthwhile to look into.